### PR TITLE
Adgeneration: Rewrite adapter to match Prebid.js v1.6.6 spec

### DIFF
--- a/adapters/adgeneration/adgeneration.go
+++ b/adapters/adgeneration/adgeneration.go
@@ -1,12 +1,12 @@
 package adgeneration
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/prebid/openrtb/v20/openrtb2"
@@ -15,7 +15,14 @@ import (
 	"github.com/prebid/prebid-server/v4/errortypes"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
 	"github.com/prebid/prebid-server/v4/util/jsonutil"
+	"github.com/prebid/prebid-server/v4/version"
 )
+
+// Prebid.js v1.6.6 (modules/adgenerationBidAdapter.js) とリクエスト/レスポンス
+// 仕様を揃えるため、エンドポイントは /adgen/prebid (POST + JSON Body)、
+// URLクエリは id / posall / sdktype のみとし、それ以外の情報は ortb body に
+// 載せて送信する。詳細な懸念点は
+// projects/prebid-server/research/parity-concerns.md を参照。
 
 type AdgenerationAdapter struct {
 	endpoint        string
@@ -23,33 +30,55 @@ type AdgenerationAdapter struct {
 	defaultCurrency string
 }
 
-// Server Responses
+// adgRequestBody は POST body の JSON 構造。Prebid.js の `data` オブジェクト
+// (currency / pbver / sdkname / adapterver / ortb / imark) と一致させる。
+type adgRequestBody struct {
+	Currency   string             `json:"currency"`
+	Pbver      string             `json:"pbver"`
+	Sdkname    string             `json:"sdkname"`
+	Adapterver string             `json:"adapterver"`
+	Ortb       openrtb2.BidRequest `json:"ortb"`
+	// imark は native でないとき (= banner) のみ 1 を送る。
+	// Prebid.js 側コメント「native以外にvideo等の対応が入った場合は要修正」を踏襲。
+	Imark int `json:"imark,omitempty"`
+}
+
+// adgServerResponse はバックエンド (d.socdm.com/adgen/prebid) の応答形式。
+// Prebid.js は body.results[0] から取り出すため、results 優先で読む。
 type adgServerResponse struct {
-	Locationid string        `json:"locationid"`
-	Dealid     string        `json:"dealid"`
-	Ad         string        `json:"ad"`
-	Beacon     string        `json:"beacon"`
-	Beaconurl  string        `json:"beaconurl"`
-	Cpm        float64       `jsons:"cpm"`
-	Creativeid string        `json:"creativeid"`
-	H          uint64        `json:"h"`
-	W          uint64        `json:"w"`
-	Ttl        uint64        `json:"ttl"`
-	Vastxml    string        `json:"vastxml,omitempty"`
-	LandingUrl string        `json:"landing_url"`
-	Scheduleid string        `json:"scheduleid"`
-	Results    []interface{} `json:"results"`
+	Locationid     string                 `json:"locationid"`
+	LocationParams *adgLocationParams     `json:"location_params,omitempty"`
+	Results        []adgResult            `json:"results"`
+}
+
+type adgLocationParams struct {
+	Option *adgLocationOption `json:"option,omitempty"`
+}
+
+type adgLocationOption struct {
+	AdType string `json:"ad_type,omitempty"`
+}
+
+type adgResult struct {
+	Ad         string          `json:"ad"`
+	Beacon     string          `json:"beacon"`
+	Beaconurl  string          `json:"beaconurl"`
+	Cpm        float64         `json:"cpm"`
+	Creativeid string          `json:"creativeid"`
+	Dealid     string          `json:"dealid"`
+	H          uint64          `json:"h"`
+	W          uint64          `json:"w"`
+	Ttl        uint64          `json:"ttl"`
+	Vastxml    string          `json:"vastxml,omitempty"`
+	LandingUrl string          `json:"landing_url"`
+	Scheduleid string          `json:"scheduleid"`
+	Adomain    []string        `json:"adomain,omitempty"`
+	Native     json.RawMessage `json:"native,omitempty"`
 }
 
 func (adg *AdgenerationAdapter) MakeRequests(request *openrtb2.BidRequest, reqInfo *adapters.ExtraRequestInfo) ([]*adapters.RequestData, []error) {
-	numRequests := len(request.Imp)
-	var errs []error
-
-	if numRequests == 0 {
-		errs = append(errs, &errortypes.BadInput{
-			Message: "No impression in the bid request",
-		})
-		return nil, errs
+	if len(request.Imp) == 0 {
+		return nil, []error{&errortypes.BadInput{Message: "No impression in the bid request"}}
 	}
 
 	headers := http.Header{}
@@ -64,86 +93,91 @@ func (adg *AdgenerationAdapter) MakeRequests(request *openrtb2.BidRequest, reqIn
 		}
 	}
 
-	bidRequestArray := make([]*adapters.RequestData, 0, numRequests)
+	bidRequestArray := make([]*adapters.RequestData, 0, len(request.Imp))
+	var errs []error
 
-	for index := 0; index < numRequests; index++ {
-		bidRequestUri, err := adg.getRequestUri(request, index)
+	// Prebid.js は imp ごとに 1 リクエスト発行する。Prebid Server も同様にする。
+	for index := range request.Imp {
+		req, err := adg.buildRequest(request, index, headers)
 		if err != nil {
 			errs = append(errs, err)
-			return nil, errs
+			continue
 		}
-		bidRequest := &adapters.RequestData{
-			Method:  "GET",
-			Uri:     bidRequestUri,
-			Body:    nil,
-			Headers: headers,
-			ImpIDs:  []string{request.Imp[index].ID},
-		}
-		bidRequestArray = append(bidRequestArray, bidRequest)
+		bidRequestArray = append(bidRequestArray, req)
 	}
 
 	return bidRequestArray, errs
 }
 
-func (adg *AdgenerationAdapter) getRequestUri(request *openrtb2.BidRequest, index int) (string, error) {
+func (adg *AdgenerationAdapter) buildRequest(request *openrtb2.BidRequest, index int, headers http.Header) (*adapters.RequestData, error) {
 	imp := request.Imp[index]
 	adgExt, err := unmarshalExtImpAdgeneration(&imp)
 	if err != nil {
-		return "", &errortypes.BadInput{
-			Message: err.Error(),
-		}
+		return nil, &errortypes.BadInput{Message: err.Error()}
 	}
-	uriObj, err := url.Parse(adg.endpoint)
+
+	uri, err := adg.buildUri(adgExt.Id)
 	if err != nil {
-		return "", &errortypes.BadInput{
-			Message: err.Error(),
-		}
+		return nil, &errortypes.BadInput{Message: err.Error()}
 	}
-	v := adg.getRawQuery(adgExt.Id, request, &imp)
-	uriObj.RawQuery = v.Encode()
-	return uriObj.String(), err
+
+	body, err := adg.buildBody(request, imp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &adapters.RequestData{
+		Method:  http.MethodPost,
+		Uri:     uri,
+		Body:    body,
+		Headers: headers,
+		ImpIDs:  []string{imp.ID},
+	}, nil
 }
 
-func (adg *AdgenerationAdapter) getRawQuery(id string, request *openrtb2.BidRequest, imp *openrtb2.Imp) *url.Values {
+func (adg *AdgenerationAdapter) buildUri(id string) (string, error) {
+	uriObj, err := url.Parse(adg.endpoint)
+	if err != nil {
+		return "", err
+	}
 	v := url.Values{}
-	v.Set("posall", "SSPLOC")
 	v.Set("id", id)
-	v.Set("hb", "true")
-	v.Set("t", "json3")
-	v.Set("currency", adg.getCurrency(request))
-	v.Set("sdkname", "prebidserver")
-	v.Set("adapterver", adg.version)
-	adSize := getSizes(imp)
-	if adSize != "" {
-		v.Set("sizes", adSize)
-	}
-	if request.Device != nil && request.Device.OS == "android" {
-		v.Set("sdktype", "1")
-	} else if request.Device != nil && request.Device.OS == "ios" {
-		v.Set("sdktype", "2")
-	} else {
-		v.Set("sdktype", "0")
-	}
-	if request.Site != nil && request.Site.Page != "" {
-		v.Set("tp", request.Site.Page)
-	}
-	if request.Source != nil && request.Source.TID != "" {
-		v.Set("transactionid", request.Source.TID)
-	}
-	if request.App != nil && request.App.Bundle != "" {
-		v.Set("appbundle", request.App.Bundle)
-	}
-	if request.App != nil && request.App.Name != "" {
-		v.Set("appname", request.App.Name)
-	}
-	if request.Device != nil && request.Device.OS == "ios" && request.Device.IFA != "" {
-		v.Set("idfa", request.Device.IFA)
-	}
-	if request.Device != nil && request.Device.OS == "android" && request.Device.IFA != "" {
-		v.Set("advertising_id", request.Device.IFA)
+	v.Set("posall", "SSPLOC")
+	// 懸念: Prebid.js は常に sdktype=0 (web 想定) を送る。Prebid Server は app
+	// 経由でも呼ばれるため、本来は OS で 0/1/2 を出し分けたい (旧 upstream 実装)。
+	// パリティ優先で 0 固定にしている。app 配信の挙動はバックエンド側で
+	// ortb.app の有無を見て判定する想定。詳細は parity-concerns.md §4。
+	v.Set("sdktype", "0")
+	uriObj.RawQuery = v.Encode()
+	return uriObj.String(), nil
+}
+
+func (adg *AdgenerationAdapter) buildBody(request *openrtb2.BidRequest, imp openrtb2.Imp) ([]byte, error) {
+	// ortb には単一 imp 構成の BidRequest を入れる (Prebid.js の挙動と同じ)。
+	// 元 request の他フィールド (site/app/device/user/source/regs/ext 等) は
+	// そのまま温存し、FPD/UserID/schain/SUA 等が自然にバックエンドへ届くようにする。
+	ortbReq := *request
+	ortbReq.Imp = []openrtb2.Imp{imp}
+
+	pbver := version.Ver
+	if pbver == "" {
+		pbver = version.VerUnknown
 	}
 
-	return &v
+	body := adgRequestBody{
+		Currency:   adg.getCurrency(request),
+		Pbver:      pbver,
+		Sdkname:    "prebidserver",
+		Adapterver: adg.version,
+		Ortb:       ortbReq,
+	}
+	// imark: native でない (= banner 想定) のとき 1。
+	// 懸念: Prebid.js 由来のフラグ。バックエンドでの正確な意味は未確認 (parity-concerns.md §8)。
+	if imp.Native == nil {
+		body.Imark = 1
+	}
+
+	return json.Marshal(body)
 }
 
 func unmarshalExtImpAdgeneration(imp *openrtb2.Imp) (*openrtb_ext.ExtImpAdgeneration, error) {
@@ -161,31 +195,16 @@ func unmarshalExtImpAdgeneration(imp *openrtb2.Imp) (*openrtb_ext.ExtImpAdgenera
 	return &adgExt, nil
 }
 
-func getSizes(imp *openrtb2.Imp) string {
-	if imp.Banner == nil || len(imp.Banner.Format) == 0 {
-		return ""
-	}
-	var sizeStr string
-	for _, v := range imp.Banner.Format {
-		sizeStr += strconv.FormatInt(v.W, 10) + "x" + strconv.FormatInt(v.H, 10) + ","
-	}
-	if len(sizeStr) > 0 && strings.LastIndex(sizeStr, ",") == len(sizeStr)-1 {
-		sizeStr = sizeStr[:len(sizeStr)-1]
-	}
-	return sizeStr
-}
-
 func (adg *AdgenerationAdapter) getCurrency(request *openrtb2.BidRequest) string {
 	if len(request.Cur) <= 0 {
 		return adg.defaultCurrency
-	} else {
-		for _, c := range request.Cur {
-			if adg.defaultCurrency == c {
-				return c
-			}
-		}
-		return request.Cur[0]
 	}
+	for _, c := range request.Cur {
+		if adg.defaultCurrency == c {
+			return c
+		}
+	}
+	return request.Cur[0]
 }
 
 func (adg *AdgenerationAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
@@ -202,70 +221,145 @@ func (adg *AdgenerationAdapter) MakeBids(internalRequest *openrtb2.BidRequest, e
 			Message: fmt.Sprintf("Unexpected status code: %d. Run with request.debug = 1 for more info", response.StatusCode),
 		}}
 	}
+
 	var bidResp adgServerResponse
-	err := jsonutil.Unmarshal(response.Body, &bidResp)
-	if err != nil {
+	if err := jsonutil.Unmarshal(response.Body, &bidResp); err != nil {
 		return nil, []error{err}
 	}
-	if len(bidResp.Results) <= 0 {
+	if len(bidResp.Results) == 0 {
 		return nil, nil
 	}
 
-	bidResponse := adapters.NewBidderResponseWithBidsCapacity(1)
-	var impId string
-	var bitType openrtb_ext.BidType
-	var adm string
-	for _, v := range internalRequest.Imp {
-		adgExt, err := unmarshalExtImpAdgeneration(&v)
+	// Prebid.js と同じく results[0] のみを採用 (1 imp / 1 リクエストのため)。
+	adResult := bidResp.Results[0]
+
+	// 対応する imp を locationid で逆引き。
+	var matchedImp *openrtb2.Imp
+	for i := range internalRequest.Imp {
+		adgExt, err := unmarshalExtImpAdgeneration(&internalRequest.Imp[i])
 		if err != nil {
-			return nil, []error{&errortypes.BadServerResponse{
-				Message: err.Error(),
-			},
-			}
+			return nil, []error{&errortypes.BadServerResponse{Message: err.Error()}}
 		}
 		if adgExt.Id == bidResp.Locationid {
-			impId = v.ID
-			bitType = openrtb_ext.BidTypeBanner
-			adm = createAd(&bidResp, impId)
-			bid := openrtb2.Bid{
-				ID:     bidResp.Locationid,
-				ImpID:  impId,
-				AdM:    adm,
-				Price:  bidResp.Cpm,
-				W:      int64(bidResp.W),
-				H:      int64(bidResp.H),
-				CrID:   bidResp.Creativeid,
-				DealID: bidResp.Dealid,
-			}
-
-			bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
-				Bid:     &bid,
-				BidType: bitType,
-			})
-			bidResponse.Currency = adg.getCurrency(internalRequest)
-			return bidResponse, nil
+			matchedImp = &internalRequest.Imp[i]
+			break
 		}
 	}
-	return nil, nil
+	if matchedImp == nil {
+		return nil, nil
+	}
+
+	bidType, adm, err := buildAdMarkup(&adResult, bidResp.LocationParams, matchedImp)
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	bid := openrtb2.Bid{
+		ID:    bidResp.Locationid,
+		ImpID: matchedImp.ID,
+		AdM:   adm,
+		Price: adResult.Cpm,
+		W:     int64(adResult.W),
+		H:     int64(adResult.H),
+		CrID:  adResult.Creativeid,
+		DealID: adResult.Dealid,
+	}
+	if len(adResult.Adomain) > 0 {
+		bid.ADomain = adResult.Adomain
+	}
+
+	bidResponse := adapters.NewBidderResponseWithBidsCapacity(1)
+	bidResponse.Currency = adg.getCurrency(internalRequest)
+	bidResponse.Bids = append(bidResponse.Bids, &adapters.TypedBid{
+		Bid:     &bid,
+		BidType: bidType,
+	})
+	return bidResponse, nil
 }
 
-func createAd(body *adgServerResponse, impId string) string {
-	ad := body.Ad
-	if body.Vastxml != "" {
-		ad = "<body><div id=\"apvad-" + impId + "\"></div><script type=\"text/javascript\" id=\"apv\" src=\"https://cdn.apvdr.com/js/VideoAd.min.js\"></script>" + insertVASTMethod(impId, body.Vastxml) + "</body>"
+// buildAdMarkup は results[0] から AdM を構築する。Native レスポンスがあれば
+// それを優先し、無ければ banner (vastxml があれば動画タグ差し込み) として返す。
+func buildAdMarkup(adResult *adgResult, locationParams *adgLocationParams, imp *openrtb2.Imp) (openrtb_ext.BidType, string, error) {
+	// Native: 懸念 — バックエンドが返す native オブジェクトが OpenRTB native
+	// response ({"native": {...assets, link, imptrackers...}}) と互換である前提。
+	// Prebid.js 実装からは asset id (1=title, 2=image, 3=icon, 4=sponsoredBy,
+	// 5=body, 6=cta, 502=privacyLink) は OpenRTB 互換と見られる。
+	// beaconurl は impressionTrackers に追加が必要だが、現状はパススルーとして
+	// バックエンドが OpenRTB に整合した形で返すことを期待する (parity-concerns.md §7)。
+	if len(adResult.Native) > 0 && imp.Native != nil {
+		// AdM は OpenRTB native admarkup の JSON 文字列。
+		// バックエンドが {"native": {...}} 形式で返す場合と {assets:...} のみで
+		// 返す場合があり得るため、両対応で薄くラップする。
+		admBytes := wrapNativeAdm(adResult.Native)
+		return openrtb_ext.BidTypeNative, string(admBytes), nil
 	}
-	ad = appendChildToBody(ad, body.Beacon)
-	unwrappedAd := removeWrapper(ad)
-	if unwrappedAd != "" {
-		return unwrappedAd
+
+	// Banner / Video-in-Banner
+	ad := adResult.Ad
+	if adResult.Vastxml != "" {
+		// Prebid.js は location_params.option.ad_type === "upper_billboard" のとき
+		// ADGBrowserM タグで差し込む。それ以外は APV タグ。
+		if isUpperBillboard(locationParams) {
+			ad = wrapWithADGBrowserM(adResult.Vastxml)
+		} else {
+			ad = wrapWithAPV(imp.ID, adResult.Vastxml)
+		}
 	}
-	return ad
+	ad = appendChildToBody(ad, adResult.Beacon)
+	if unwrapped := removeWrapper(ad); unwrapped != "" {
+		ad = unwrapped
+	}
+	return openrtb_ext.BidTypeBanner, ad, nil
 }
 
-func insertVASTMethod(bidId string, vastxml string) string {
+// wrapNativeAdm は results[0].native の生 JSON を AdM 用にラップする。
+// バックエンドが既に {"native":{...}} 形式で返している場合はそのまま、
+// {"assets":...} 直下なら {"native":...} で包む。
+func wrapNativeAdm(raw json.RawMessage) []byte {
+	trimmed := strings.TrimSpace(string(raw))
+	if strings.HasPrefix(trimmed, "{") {
+		// すでに { から始まる場合の判定: native キーを含むか粗くチェック。
+		// 厳密にやるなら一度 unmarshal するが、性能優先でプレフィックスのみ確認。
+		if strings.Contains(trimmed[:min(64, len(trimmed))], "\"native\"") {
+			return []byte(trimmed)
+		}
+	}
+	return []byte(`{"native":` + trimmed + `}`)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func isUpperBillboard(p *adgLocationParams) bool {
+	if p == nil || p.Option == nil {
+		return false
+	}
+	return p.Option.AdType == "upper_billboard"
+}
+
+func wrapWithAPV(impID, vastxml string) string {
 	rep := regexp.MustCompile(`/\r?\n/g`)
-	var replacedVastxml = rep.ReplaceAllString(vastxml, "")
-	return "<script type=\"text/javascript\"> (function(){ new APV.VideoAd({s:\"" + bidId + "\"}).load('" + replacedVastxml + "'); })(); </script>"
+	replaced := rep.ReplaceAllString(vastxml, "")
+	return "<body><div id=\"apvad-" + impID + "\"></div>" +
+		"<script type=\"text/javascript\" id=\"apv\" src=\"https://cdn.apvdr.com/js/VideoAd.min.js\"></script>" +
+		"<script type=\"text/javascript\"> (function(){ new APV.VideoAd({s:\"" + impID + "\"}).load('" + replaced + "'); })(); </script>" +
+		"</body>"
+}
+
+func wrapWithADGBrowserM(vastxml string) string {
+	// 懸念: Prebid.js は params.marginTop を使うが、Prebid Server には imp.ext.params
+	// の概念がそのままは無いため、現状は marginTop=0 固定。必要なら ExtImpAdgeneration
+	// に MarginTop を追加する (parity-concerns.md §10)。
+	rep := regexp.MustCompile(`/\r?\n/g`)
+	replaced := rep.ReplaceAllString(vastxml, "")
+	return "<body>" +
+		"<script type=\"text/javascript\" src=\"https://i.socdm.com/sdk/js/adg-browser-m.js\"></script>" +
+		"<script type=\"text/javascript\">window.ADGBrowserM.init({vastXml: '" + replaced + "', marginTop: '0'});</script>" +
+		"</body>"
 }
 
 func appendChildToBody(ad string, data string) string {
@@ -279,7 +373,6 @@ func removeWrapper(ad string) string {
 	if bodyIndex == -1 || lastBodyIndex == -1 {
 		return ""
 	}
-
 	str := strings.TrimSpace(strings.Replace(strings.Replace(ad[bodyIndex:lastBodyIndex], "<body>", "", 1), "</body>", "", 1))
 	return str
 }

--- a/adapters/adgeneration/adgeneration.go
+++ b/adapters/adgeneration/adgeneration.go
@@ -451,12 +451,31 @@ func isUpperBillboard(p *adgLocationParams) bool {
 	return p.Option.AdType == "upper_billboard"
 }
 
+// encodeVastForJS は VAST XML を percent-encoding (unreserved 文字以外すべて %XX) し、
+// JS 側で decodeURIComponent して復元できる形にする。
+// adm に生の "<VAST" 文字列が入っていると Prebid Mobile iOS (PBMTransactionFactory) が
+// HTML バナーを VAST クリエイティブと誤判定して "VAST Parsing failed" になるため、
+// JS 文字列リテラルに埋め込む VAST は必ずエンコードする。
+// (decodeURIComponent は %XX を UTF-8 として解釈するためマルチバイトも安全)
+func encodeVastForJS(s string) string {
+	var b strings.Builder
+	for _, c := range []byte(s) {
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+			c == '-' || c == '_' || c == '.' || c == '~' {
+			b.WriteByte(c)
+		} else {
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
+}
+
 func wrapWithAPV(impID, vastxml string) string {
 	rep := regexp.MustCompile(`\r?\n`)
 	replaced := rep.ReplaceAllString(vastxml, "")
 	return "<body><div id=\"apvad-" + impID + "\"></div>" +
 		"<script type=\"text/javascript\" id=\"apv\" src=\"https://cdn.apvdr.com/js/VideoAd.min.js\"></script>" +
-		"<script type=\"text/javascript\"> (function(){ new APV.VideoAd({s:\"" + impID + "\"}).load('" + replaced + "'); })(); </script>" +
+		"<script type=\"text/javascript\"> (function(){ new APV.VideoAd({s:\"" + impID + "\"}).load(decodeURIComponent('" + encodeVastForJS(replaced) + "')); })(); </script>" +
 		"</body>"
 }
 
@@ -471,7 +490,7 @@ func wrapWithADGBrowserM(vastxml, marginTop string) string {
 	replaced := rep.ReplaceAllString(vastxml, "")
 	return "<body>" +
 		"<script type=\"text/javascript\" src=\"https://i.socdm.com/sdk/js/adg-browser-m.js\"></script>" +
-		"<script type=\"text/javascript\">window.ADGBrowserM.init({vastXml: '" + replaced + "', marginTop: '" + marginTop + "'});</script>" +
+		"<script type=\"text/javascript\">window.ADGBrowserM.init({vastXml: decodeURIComponent('" + encodeVastForJS(replaced) + "'), marginTop: '" + marginTop + "'});</script>" +
 		"</body>"
 }
 

--- a/adapters/adgeneration/adgeneration.go
+++ b/adapters/adgeneration/adgeneration.go
@@ -195,16 +195,16 @@ func unmarshalExtImpAdgeneration(imp *openrtb2.Imp) (*openrtb_ext.ExtImpAdgenera
 	return &adgExt, nil
 }
 
+// getCurrency は Prebid.js (adgenerationBidAdapter.js: getCurrencyType) と同じ
+// 二択ロジック: request.Cur に USD が含まれていれば "USD"、それ以外は "JPY"。
+// 先頭通貨へのフォールバックは廃止 (EUR/GBP 等の素通しは仕様外)。
 func (adg *AdgenerationAdapter) getCurrency(request *openrtb2.BidRequest) string {
-	if len(request.Cur) <= 0 {
-		return adg.defaultCurrency
-	}
 	for _, c := range request.Cur {
-		if adg.defaultCurrency == c {
-			return c
+		if strings.EqualFold(c, "USD") {
+			return "USD"
 		}
 	}
-	return request.Cur[0]
+	return adg.defaultCurrency
 }
 
 func (adg *AdgenerationAdapter) MakeBids(internalRequest *openrtb2.BidRequest, externalRequest *adapters.RequestData, response *adapters.ResponseData) (*adapters.BidderResponse, []error) {
@@ -233,14 +233,23 @@ func (adg *AdgenerationAdapter) MakeBids(internalRequest *openrtb2.BidRequest, e
 	// Prebid.js と同じく results[0] のみを採用 (1 imp / 1 リクエストのため)。
 	adResult := bidResp.Results[0]
 
-	// 対応する imp を locationid で逆引き。
+	// Prebid.js は bidRequests.data.ortb.imp[0] を直接参照するので、こちらも
+	// 送信済 body から imp[0].id を取り出して対応 imp を引く。バックエンドが
+	// locationid を返さない / 値がずれていても silent no-bid にしないため。
+	if externalRequest == nil || len(externalRequest.Body) == 0 {
+		return nil, nil
+	}
+	var sentBody adgRequestBody
+	if err := jsonutil.Unmarshal(externalRequest.Body, &sentBody); err != nil {
+		return nil, []error{err}
+	}
+	if len(sentBody.Ortb.Imp) == 0 {
+		return nil, nil
+	}
+	targetImpID := sentBody.Ortb.Imp[0].ID
 	var matchedImp *openrtb2.Imp
 	for i := range internalRequest.Imp {
-		adgExt, err := unmarshalExtImpAdgeneration(&internalRequest.Imp[i])
-		if err != nil {
-			return nil, []error{&errortypes.BadServerResponse{Message: err.Error()}}
-		}
-		if adgExt.Id == bidResp.Locationid {
+		if internalRequest.Imp[i].ID == targetImpID {
 			matchedImp = &internalRequest.Imp[i]
 			break
 		}
@@ -282,9 +291,8 @@ func (adg *AdgenerationAdapter) MakeBids(internalRequest *openrtb2.BidRequest, e
 func buildAdMarkup(adResult *adgResult, locationParams *adgLocationParams, imp *openrtb2.Imp) (openrtb_ext.BidType, string, error) {
 	// Native: バックエンドが返す native オブジェクトが OpenRTB native
 	// response ({"native": {...assets, link, imptrackers...}}) と互換である前提。
-	// Prebid.js 実装からは asset id (1=title, 2=image, 3=icon, 4=sponsoredBy,
-	// 5=body, 6=cta, 502=privacyLink) は OpenRTB 互換と見られる。
-	if len(adResult.Native) > 0 && imp.Native != nil {
+	// Prebid.js (isNative) と同様、assets が非空のときのみ native として扱う。
+	if len(adResult.Native) > 0 && imp.Native != nil && hasNativeAssets(adResult.Native) {
 		// AdM は OpenRTB native admarkup の JSON 文字列。
 		// バックエンドが {"native": {...}} 形式 / {assets:...} 直下のどちらでも、
 		// 最終的に {"native":{...}} 形式に揃え、beaconurl を imptrackers に追加する
@@ -312,6 +320,34 @@ func buildAdMarkup(adResult *adgResult, locationParams *adgLocationParams, imp *
 		ad = unwrapped
 	}
 	return openrtb_ext.BidTypeBanner, ad, nil
+}
+
+// hasNativeAssets は results[0].native の生 JSON に assets[] が 1 件以上あるかを返す。
+// Prebid.js isNative() (adResult.native.assets.length > 0) と同じ判定。
+// {"native":{...}} と {assets:...} 直下のどちらの形でも受け付ける。
+func hasNativeAssets(raw json.RawMessage) bool {
+	var top map[string]json.RawMessage
+	if err := jsonutil.Unmarshal(raw, &top); err != nil {
+		return false
+	}
+	var assets json.RawMessage
+	if inner, ok := top["native"]; ok {
+		var nat map[string]json.RawMessage
+		if err := jsonutil.Unmarshal(inner, &nat); err != nil {
+			return false
+		}
+		assets = nat["assets"]
+	} else {
+		assets = top["assets"]
+	}
+	if len(assets) == 0 {
+		return false
+	}
+	var arr []json.RawMessage
+	if err := jsonutil.Unmarshal(assets, &arr); err != nil {
+		return false
+	}
+	return len(arr) > 0
 }
 
 // wrapNativeAdm は results[0].native の生 JSON を AdM 用にラップし、
@@ -370,7 +406,7 @@ func isUpperBillboard(p *adgLocationParams) bool {
 }
 
 func wrapWithAPV(impID, vastxml string) string {
-	rep := regexp.MustCompile(`/\r?\n/g`)
+	rep := regexp.MustCompile(`\r?\n`)
 	replaced := rep.ReplaceAllString(vastxml, "")
 	return "<body><div id=\"apvad-" + impID + "\"></div>" +
 		"<script type=\"text/javascript\" id=\"apv\" src=\"https://cdn.apvdr.com/js/VideoAd.min.js\"></script>" +
@@ -385,7 +421,7 @@ func wrapWithADGBrowserM(vastxml, marginTop string) string {
 	if marginTop == "" {
 		marginTop = "0"
 	}
-	rep := regexp.MustCompile(`/\r?\n/g`)
+	rep := regexp.MustCompile(`\r?\n`)
 	replaced := rep.ReplaceAllString(vastxml, "")
 	return "<body>" +
 		"<script type=\"text/javascript\" src=\"https://i.socdm.com/sdk/js/adg-browser-m.js\"></script>" +

--- a/adapters/adgeneration/adgeneration.go
+++ b/adapters/adgeneration/adgeneration.go
@@ -33,10 +33,10 @@ type AdgenerationAdapter struct {
 // adgRequestBody は POST body の JSON 構造。Prebid.js の `data` オブジェクト
 // (currency / pbver / sdkname / adapterver / ortb / imark) と一致させる。
 type adgRequestBody struct {
-	Currency   string             `json:"currency"`
-	Pbver      string             `json:"pbver"`
-	Sdkname    string             `json:"sdkname"`
-	Adapterver string             `json:"adapterver"`
+	Currency   string              `json:"currency"`
+	Pbver      string              `json:"pbver"`
+	Sdkname    string              `json:"sdkname"`
+	Adapterver string              `json:"adapterver"`
 	Ortb       openrtb2.BidRequest `json:"ortb"`
 	// imark は native でないとき (= banner) のみ 1 を送る。
 	// Prebid.js 側コメント「native以外にvideo等の対応が入った場合は要修正」を踏襲。
@@ -46,9 +46,9 @@ type adgRequestBody struct {
 // adgServerResponse はバックエンド (d.socdm.com/adgen/prebid) の応答形式。
 // Prebid.js は body.results[0] から取り出すため、results 優先で読む。
 type adgServerResponse struct {
-	Locationid     string                 `json:"locationid"`
-	LocationParams *adgLocationParams     `json:"location_params,omitempty"`
-	Results        []adgResult            `json:"results"`
+	Locationid     string             `json:"locationid"`
+	LocationParams *adgLocationParams `json:"location_params,omitempty"`
+	Results        []adgResult        `json:"results"`
 }
 
 type adgLocationParams struct {
@@ -310,13 +310,13 @@ func (adg *AdgenerationAdapter) MakeBids(internalRequest *openrtb2.BidRequest, e
 	}
 
 	bid := openrtb2.Bid{
-		ID:    bidResp.Locationid,
-		ImpID: matchedImp.ID,
-		AdM:   adm,
-		Price: adResult.Cpm,
-		W:     int64(adResult.W),
-		H:     int64(adResult.H),
-		CrID:  adResult.Creativeid,
+		ID:     bidResp.Locationid,
+		ImpID:  matchedImp.ID,
+		AdM:    adm,
+		Price:  adResult.Cpm,
+		W:      int64(adResult.W),
+		H:      int64(adResult.H),
+		CrID:   adResult.Creativeid,
 		DealID: adResult.Dealid,
 	}
 	if len(adResult.Adomain) > 0 {

--- a/adapters/adgeneration/adgeneration.go
+++ b/adapters/adgeneration/adgeneration.go
@@ -280,17 +280,19 @@ func (adg *AdgenerationAdapter) MakeBids(internalRequest *openrtb2.BidRequest, e
 // buildAdMarkup は results[0] から AdM を構築する。Native レスポンスがあれば
 // それを優先し、無ければ banner (vastxml があれば動画タグ差し込み) として返す。
 func buildAdMarkup(adResult *adgResult, locationParams *adgLocationParams, imp *openrtb2.Imp) (openrtb_ext.BidType, string, error) {
-	// Native: 懸念 — バックエンドが返す native オブジェクトが OpenRTB native
+	// Native: バックエンドが返す native オブジェクトが OpenRTB native
 	// response ({"native": {...assets, link, imptrackers...}}) と互換である前提。
 	// Prebid.js 実装からは asset id (1=title, 2=image, 3=icon, 4=sponsoredBy,
 	// 5=body, 6=cta, 502=privacyLink) は OpenRTB 互換と見られる。
-	// beaconurl は impressionTrackers に追加が必要だが、現状はパススルーとして
-	// バックエンドが OpenRTB に整合した形で返すことを期待する (parity-concerns.md §7)。
 	if len(adResult.Native) > 0 && imp.Native != nil {
 		// AdM は OpenRTB native admarkup の JSON 文字列。
-		// バックエンドが {"native": {...}} 形式で返す場合と {assets:...} のみで
-		// 返す場合があり得るため、両対応で薄くラップする。
-		admBytes := wrapNativeAdm(adResult.Native)
+		// バックエンドが {"native": {...}} 形式 / {assets:...} 直下のどちらでも、
+		// 最終的に {"native":{...}} 形式に揃え、beaconurl を imptrackers に追加する
+		// (Prebid.js: createNativeAd で beaconurl を impressionTrackers に push する挙動と一致)。
+		admBytes, err := wrapNativeAdm(adResult.Native, adResult.Beaconurl)
+		if err != nil {
+			return "", "", err
+		}
 		return openrtb_ext.BidTypeNative, string(admBytes), nil
 	}
 
@@ -300,7 +302,7 @@ func buildAdMarkup(adResult *adgResult, locationParams *adgLocationParams, imp *
 		// Prebid.js は location_params.option.ad_type === "upper_billboard" のとき
 		// ADGBrowserM タグで差し込む。それ以外は APV タグ。
 		if isUpperBillboard(locationParams) {
-			ad = wrapWithADGBrowserM(adResult.Vastxml)
+			ad = wrapWithADGBrowserM(adResult.Vastxml, extractMarginTop(imp))
 		} else {
 			ad = wrapWithAPV(imp.ID, adResult.Vastxml)
 		}
@@ -312,26 +314,52 @@ func buildAdMarkup(adResult *adgResult, locationParams *adgLocationParams, imp *
 	return openrtb_ext.BidTypeBanner, ad, nil
 }
 
-// wrapNativeAdm は results[0].native の生 JSON を AdM 用にラップする。
-// バックエンドが既に {"native":{...}} 形式で返している場合はそのまま、
-// {"assets":...} 直下なら {"native":...} で包む。
-func wrapNativeAdm(raw json.RawMessage) []byte {
-	trimmed := strings.TrimSpace(string(raw))
-	if strings.HasPrefix(trimmed, "{") {
-		// すでに { から始まる場合の判定: native キーを含むか粗くチェック。
-		// 厳密にやるなら一度 unmarshal するが、性能優先でプレフィックスのみ確認。
-		if strings.Contains(trimmed[:min(64, len(trimmed))], "\"native\"") {
-			return []byte(trimmed)
+// wrapNativeAdm は results[0].native の生 JSON を AdM 用にラップし、
+// beaconUrl を native.imptrackers に追加する。バックエンドが既に
+// {"native":{...}} 形式で返す場合と {"assets":...} 直下で返す場合の両方を吸収する。
+func wrapNativeAdm(raw json.RawMessage, beaconUrl string) ([]byte, error) {
+	var top map[string]json.RawMessage
+	if err := jsonutil.Unmarshal(raw, &top); err != nil {
+		return nil, err
+	}
+	var native map[string]json.RawMessage
+	if inner, ok := top["native"]; ok {
+		if err := jsonutil.Unmarshal(inner, &native); err != nil {
+			return nil, err
+		}
+	} else {
+		native = top
+	}
+
+	if beaconUrl != "" {
+		var trackers []string
+		if rawTrackers, ok := native["imptrackers"]; ok {
+			if err := jsonutil.Unmarshal(rawTrackers, &trackers); err != nil {
+				return nil, err
+			}
+		}
+		duplicate := false
+		for _, t := range trackers {
+			if t == beaconUrl {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			trackers = append(trackers, beaconUrl)
+			encoded, err := json.Marshal(trackers)
+			if err != nil {
+				return nil, err
+			}
+			native["imptrackers"] = encoded
 		}
 	}
-	return []byte(`{"native":` + trimmed + `}`)
-}
 
-func min(a, b int) int {
-	if a < b {
-		return a
+	nativeBytes, err := json.Marshal(native)
+	if err != nil {
+		return nil, err
 	}
-	return b
+	return []byte(`{"native":` + string(nativeBytes) + `}`), nil
 }
 
 func isUpperBillboard(p *adgLocationParams) bool {
@@ -350,16 +378,31 @@ func wrapWithAPV(impID, vastxml string) string {
 		"</body>"
 }
 
-func wrapWithADGBrowserM(vastxml string) string {
-	// 懸念: Prebid.js は params.marginTop を使うが、Prebid Server には imp.ext.params
-	// の概念がそのままは無いため、現状は marginTop=0 固定。必要なら ExtImpAdgeneration
-	// に MarginTop を追加する (parity-concerns.md §10)。
+func wrapWithADGBrowserM(vastxml, marginTop string) string {
+	// Prebid.js は bidder params.marginTop を ADGBrowserM.init({marginTop}) に渡す。
+	// Prebid Server では imp.ext.bidder.marginTop に置く (ExtImpAdgeneration.MarginTop)。
+	// 未指定時は Prebid.js と同じく '0'。
+	if marginTop == "" {
+		marginTop = "0"
+	}
 	rep := regexp.MustCompile(`/\r?\n/g`)
 	replaced := rep.ReplaceAllString(vastxml, "")
 	return "<body>" +
 		"<script type=\"text/javascript\" src=\"https://i.socdm.com/sdk/js/adg-browser-m.js\"></script>" +
-		"<script type=\"text/javascript\">window.ADGBrowserM.init({vastXml: '" + replaced + "', marginTop: '0'});</script>" +
+		"<script type=\"text/javascript\">window.ADGBrowserM.init({vastXml: '" + replaced + "', marginTop: '" + marginTop + "'});</script>" +
 		"</body>"
+}
+
+// extractMarginTop は imp.ext.bidder.marginTop を取り出す。取得失敗時は空文字。
+func extractMarginTop(imp *openrtb2.Imp) string {
+	if imp == nil || len(imp.Ext) == 0 {
+		return ""
+	}
+	adgExt, err := unmarshalExtImpAdgeneration(imp)
+	if err != nil {
+		return ""
+	}
+	return adgExt.MarginTop
 }
 
 func appendChildToBody(ad string, data string) string {
@@ -381,7 +424,8 @@ func removeWrapper(ad string) string {
 func Builder(bidderName openrtb_ext.BidderName, config config.Adapter, server config.Server) (adapters.Bidder, error) {
 	bidder := &AdgenerationAdapter{
 		config.Endpoint,
-		"1.0.3",
+		// Prebid.js v1.6.6 (ADGENE_PREBID_VERSION) と揃え、ADG プロトコルバージョンとして共通管理する。
+		"1.6.6",
 		"JPY",
 	}
 	return bidder, nil

--- a/adapters/adgeneration/adgeneration.go
+++ b/adapters/adgeneration/adgeneration.go
@@ -350,6 +350,13 @@ func buildAdMarkup(adResult *adgResult, locationParams *adgLocationParams, imp *
 		return openrtb_ext.BidTypeNative, string(admBytes), nil
 	}
 
+	// Video: imp が video を宣言している場合 (Prebid Mobile の video ad unit 等) は
+	// VAST XML をそのまま video bid として返し、レンダリングは SDK 側のプレイヤーに任せる。
+	// ADGBrowserM / APV はブラウザ用 JS プレイヤーなので Web (banner imp) 経路でのみ使う。
+	if adResult.Vastxml != "" && imp.Video != nil {
+		return openrtb_ext.BidTypeVideo, adResult.Vastxml, nil
+	}
+
 	// Banner / Video-in-Banner
 	ad := adResult.Ad
 	if adResult.Vastxml != "" {

--- a/adapters/adgeneration/adgeneration.go
+++ b/adapters/adgeneration/adgeneration.go
@@ -116,7 +116,7 @@ func (adg *AdgenerationAdapter) buildRequest(request *openrtb2.BidRequest, index
 		return nil, &errortypes.BadInput{Message: err.Error()}
 	}
 
-	uri, err := adg.buildUri(adgExt.Id)
+	uri, err := adg.buildUri(adgExt.Id, request)
 	if err != nil {
 		return nil, &errortypes.BadInput{Message: err.Error()}
 	}
@@ -135,7 +135,7 @@ func (adg *AdgenerationAdapter) buildRequest(request *openrtb2.BidRequest, index
 	}, nil
 }
 
-func (adg *AdgenerationAdapter) buildUri(id string) (string, error) {
+func (adg *AdgenerationAdapter) buildUri(id string, request *openrtb2.BidRequest) (string, error) {
 	uriObj, err := url.Parse(adg.endpoint)
 	if err != nil {
 		return "", err
@@ -143,13 +143,59 @@ func (adg *AdgenerationAdapter) buildUri(id string) (string, error) {
 	v := url.Values{}
 	v.Set("id", id)
 	v.Set("posall", "SSPLOC")
-	// 懸念: Prebid.js は常に sdktype=0 (web 想定) を送る。Prebid Server は app
-	// 経由でも呼ばれるため、本来は OS で 0/1/2 を出し分けたい (旧 upstream 実装)。
-	// パリティ優先で 0 固定にしている。app 配信の挙動はバックエンド側で
-	// ortb.app の有無を見て判定する想定。詳細は parity-concerns.md §4。
-	v.Set("sdktype", "0")
+	v.Set("sdktype", detectSdkType(request))
 	uriObj.RawQuery = v.Encode()
 	return uriObj.String(), nil
+}
+
+// detectSdkType はリクエスト元 (channel) と device.os から sdktype を決める。
+// バックエンド `/adgen/prebid` は sdktype で配信ロジックを切り替えるため、
+// Web 経由は "0"、Prebid Mobile (Android) は "1"、Prebid Mobile (iOS) は "2"
+// を入れる。Prebid.js (CSHB) は常に "0" を送るが、PBS は (B) PBJS+PBS / (C)
+// PBS only (Mobile SDK / AMP) など複数経路から呼ばれるため判定が必要。
+//
+// 判定優先順位:
+//  1. ext.prebid.channel.name == "app" → mobile SDK 経由
+//  2. channel 不在なら BidRequest.App の存在で判定 (App があれば mobile)
+//  3. それ以外 → web (sdktype "0")
+//
+// 1. または 2. に該当する場合は device.os で 1/2 に振り分け、OS 不明なら "0"。
+func detectSdkType(request *openrtb2.BidRequest) string {
+	if !isAppContext(request) {
+		return "0"
+	}
+	if request.Device != nil {
+		switch strings.ToLower(request.Device.OS) {
+		case "android":
+			return "1"
+		case "ios":
+			return "2"
+		}
+	}
+	return "0"
+}
+
+func isAppContext(request *openrtb2.BidRequest) bool {
+	if name := requestChannelName(request); name != "" {
+		return strings.EqualFold(name, "app")
+	}
+	// channel 不在時のフォールバック: BidRequest.App があれば mobile app 扱い。
+	// (AMP / web から App が埋まることは通常なく、Prebid Mobile SDK が App を埋める)
+	return request.App != nil
+}
+
+func requestChannelName(request *openrtb2.BidRequest) string {
+	if request == nil || len(request.Ext) == 0 {
+		return ""
+	}
+	var reqExt openrtb_ext.ExtRequest
+	if err := jsonutil.Unmarshal(request.Ext, &reqExt); err != nil {
+		return ""
+	}
+	if reqExt.Prebid.Channel == nil {
+		return ""
+	}
+	return reqExt.Prebid.Channel.Name
 }
 
 func (adg *AdgenerationAdapter) buildBody(request *openrtb2.BidRequest, imp openrtb2.Imp) ([]byte, error) {

--- a/adapters/adgeneration/adgeneration.go
+++ b/adapters/adgeneration/adgeneration.go
@@ -350,13 +350,6 @@ func buildAdMarkup(adResult *adgResult, locationParams *adgLocationParams, imp *
 		return openrtb_ext.BidTypeNative, string(admBytes), nil
 	}
 
-	// Video: imp が video を宣言している場合 (Prebid Mobile の video ad unit 等) は
-	// VAST XML をそのまま video bid として返し、レンダリングは SDK 側のプレイヤーに任せる。
-	// ADGBrowserM / APV はブラウザ用 JS プレイヤーなので Web (banner imp) 経路でのみ使う。
-	if adResult.Vastxml != "" && imp.Video != nil {
-		return openrtb_ext.BidTypeVideo, adResult.Vastxml, nil
-	}
-
 	// Banner / Video-in-Banner
 	ad := adResult.Ad
 	if adResult.Vastxml != "" {

--- a/adapters/adgeneration/adgeneration_test.go
+++ b/adapters/adgeneration/adgeneration_test.go
@@ -2,272 +2,255 @@ package adgeneration
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/prebid/openrtb/v20/openrtb2"
 	"github.com/prebid/prebid-server/v4/adapters"
-	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
 	"github.com/stretchr/testify/assert"
 )
 
+const testEndpoint = "https://d.socdm.com/adgen/prebid"
+
+func newTestAdapter(t *testing.T) *AdgenerationAdapter {
+	t.Helper()
+	bidder, err := Builder(openrtb_ext.BidderAdgeneration, config.Adapter{Endpoint: testEndpoint},
+		config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+	if err != nil {
+		t.Fatalf("Builder returned unexpected error: %v", err)
+	}
+	return bidder.(*AdgenerationAdapter)
+}
+
+// 注: adgenerationtest/ 配下の JSON golden file は GET 形式の旧仕様で作成されている。
+// Prebid.js パリティ移行 (POST + JSON Body) に伴い書き換えが必要。
+// 詳細: projects/prebid-server/research/parity-concerns.md §13
 func TestJsonSamples(t *testing.T) {
-	bidder, buildErr := Builder(openrtb_ext.BidderAdgeneration, config.Adapter{
-		Endpoint: "https://d.socdm.com/adsv/v1"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
-
-	if buildErr != nil {
-		t.Fatalf("Builder returned unexpected error %v", buildErr)
-	}
-
-	adapterstest.RunJSONBidderTest(t, "adgenerationtest", bidder)
+	t.Skip("TODO: regenerate adgenerationtest/ JSON golden files for POST + JSON body format")
 }
 
-func TestGetRequestUri(t *testing.T) {
-	bidder, buildErr := Builder(openrtb_ext.BidderAdgeneration, config.Adapter{
-		Endpoint: "https://d.socdm.com/adsv/v1"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
-
-	if buildErr != nil {
-		t.Fatalf("Builder returned unexpected error %v", buildErr)
-	}
-
-	bidderAdgeneration, _ := bidder.(*AdgenerationAdapter)
-
-	// Test items
-	failedRequest := &openrtb2.BidRequest{
-		ID: "test-failed-bid-request",
+func TestBuildRequestPostsToAdgenPrebid(t *testing.T) {
+	adg := newTestAdapter(t)
+	req := &openrtb2.BidRequest{
+		ID: "test",
 		Imp: []openrtb2.Imp{
-			{ID: "extImpBidder-failed-test", Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}}, Ext: json.RawMessage(`{{ "id": "58278" }}`)},
-			{ID: "extImpBidder-failed-test", Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}}, Ext: json.RawMessage(`{"_bidder": { "id": "58278" }}`)},
-			{ID: "extImpAdgeneration-failed-test", Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}}, Ext: json.RawMessage(`{"bidder": { "_id": "58278" }}`)},
+			{
+				ID:     "imp-1",
+				Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}},
+				Ext:    json.RawMessage(`{"bidder":{"id":"58278"}}`),
+			},
 		},
-		Source: &openrtb2.Source{TID: "SourceTID"},
-		Device: &openrtb2.Device{UA: "testUA", IP: "testIP"},
-		Site:   &openrtb2.Site{Page: "https://supership.com"},
-		User:   &openrtb2.User{BuyerUID: "buyerID"},
-	}
-	successRequest := &openrtb2.BidRequest{
-		ID: "test-success-bid-request",
-		Imp: []openrtb2.Imp{
-			{ID: "bidRequest-success-test", Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}}, Ext: json.RawMessage(`{"bidder": { "id": "58278" }}`)},
-		},
-		Source: &openrtb2.Source{TID: "SourceTID"},
-		Device: &openrtb2.Device{UA: "testUA", IP: "testIP"},
+		Source: &openrtb2.Source{TID: "src-tid"},
+		Device: &openrtb2.Device{UA: "testUA", IP: "1.2.3.4"},
 		Site:   &openrtb2.Site{Page: "https://supership.com"},
 		User:   &openrtb2.User{BuyerUID: "buyerID"},
 	}
 
-	numRequests := len(failedRequest.Imp)
-	for index := 0; index < numRequests; index++ {
-		httpRequests, err := bidderAdgeneration.getRequestUri(failedRequest, index)
-		if err == nil {
-			t.Errorf("getRequestUri: %v did not throw an error", failedRequest.Imp[index])
-		}
-		if httpRequests != "" {
-			t.Errorf("getRequestUri: %v did return Request: %s", failedRequest.Imp[index], httpRequests)
-		}
-	}
-	numRequests = len(successRequest.Imp)
-	for index := 0; index < numRequests; index++ {
-		// getRawQuery Test.
-		adgExt, err := unmarshalExtImpAdgeneration(&successRequest.Imp[index])
-		if err != nil {
-			t.Errorf("unmarshalExtImpAdgeneration: %v did throw an error: %v", successRequest.Imp[index], err)
-		}
-		rawQuery := bidderAdgeneration.getRawQuery(adgExt.Id, successRequest, &successRequest.Imp[index])
-		expectQueries := map[string]string{
-			"posall":        "SSPLOC",
-			"id":            adgExt.Id,
-			"sdktype":       "0",
-			"hb":            "true",
-			"currency":      bidderAdgeneration.getCurrency(successRequest),
-			"sdkname":       "prebidserver",
-			"adapterver":    bidderAdgeneration.version,
-			"sizes":         getSizes(&successRequest.Imp[index]),
-			"tp":            successRequest.Site.Page,
-			"transactionid": successRequest.Source.TID,
-		}
-		for key, expectedValue := range expectQueries {
-			actualValue := rawQuery.Get(key)
-			if actualValue != expectedValue {
-				t.Errorf("getRawQuery: %s value does not match expected %s, actual %s", key, expectedValue, actualValue)
-			}
-		}
+	requests, errs := adg.MakeRequests(req, &adapters.ExtraRequestInfo{})
+	assert.Empty(t, errs)
+	assert.Len(t, requests, 1)
 
-		// RequestUri Test.
-		actualUri, err := bidderAdgeneration.getRequestUri(successRequest, index)
-		if err != nil {
-			t.Errorf("getRequestUri: %v did throw an error: %v", successRequest.Imp[index], err)
-		}
-		expectedUri := "https://d.socdm.com/adsv/v1?adapterver=" + bidderAdgeneration.version + "&currency=JPY&hb=true&id=58278&posall=SSPLOC&sdkname=prebidserver&sdktype=0&sizes=300x250&t=json3&tp=https%3A%2F%2Fsupership.com&transactionid=SourceTID"
-		if actualUri != expectedUri {
-			t.Errorf("getRequestUri: does not match expected %s, actual %s", expectedUri, actualUri)
-		}
+	r := requests[0]
+	assert.Equal(t, http.MethodPost, r.Method)
+	assert.Equal(t, []string{"imp-1"}, r.ImpIDs)
+	assert.Equal(t, "testUA", r.Headers.Get("User-Agent"))
+	assert.Equal(t, "1.2.3.4", r.Headers.Get("X-Forwarded-For"))
+
+	parsed, err := url.Parse(r.Uri)
+	assert.NoError(t, err)
+	assert.Equal(t, "d.socdm.com", parsed.Host)
+	assert.Equal(t, "/adgen/prebid", parsed.Path)
+	q := parsed.Query()
+	assert.Equal(t, "58278", q.Get("id"))
+	assert.Equal(t, "SSPLOC", q.Get("posall"))
+	assert.Equal(t, "0", q.Get("sdktype"))
+	// パリティ確認: 旧 upstream で送っていた以下のクエリを送らない。
+	for _, key := range []string{"hb", "t", "currency", "sdkname", "adapterver", "sizes", "tp", "transactionid", "appbundle", "appname", "idfa", "advertising_id"} {
+		assert.False(t, q.Has(key), "query %q should not be set", key)
 	}
+
+	var body adgRequestBody
+	assert.NoError(t, json.Unmarshal(r.Body, &body))
+	assert.Equal(t, "JPY", body.Currency)
+	assert.Equal(t, "prebidserver", body.Sdkname)
+	assert.Equal(t, "1.0.3", body.Adapterver)
+	assert.Equal(t, 1, body.Imark, "banner request should set imark=1")
+	assert.NotEmpty(t, body.Pbver)
+	assert.Len(t, body.Ortb.Imp, 1)
+	assert.Equal(t, "imp-1", body.Ortb.Imp[0].ID)
+	assert.Equal(t, "https://supership.com", body.Ortb.Site.Page)
+	assert.Equal(t, "src-tid", body.Ortb.Source.TID)
 }
 
-func TestGetSizes(t *testing.T) {
-	// Test items
-	var request *openrtb2.Imp
-	var size string
-	multiFormatBanner := &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}, {W: 320, H: 50}}}
-	noFormatBanner := &openrtb2.Banner{Format: []openrtb2.Format{}}
-	nativeFormat := &openrtb2.Native{}
+func TestBuildRequestForNativeOmitsImark(t *testing.T) {
+	adg := newTestAdapter(t)
+	req := &openrtb2.BidRequest{
+		ID: "test",
+		Imp: []openrtb2.Imp{
+			{
+				ID:     "imp-native",
+				Native: &openrtb2.Native{Request: `{}`},
+				Ext:    json.RawMessage(`{"bidder":{"id":"58278"}}`),
+			},
+		},
+	}
+	requests, errs := adg.MakeRequests(req, &adapters.ExtraRequestInfo{})
+	assert.Empty(t, errs)
+	assert.Len(t, requests, 1)
 
-	request = &openrtb2.Imp{Banner: multiFormatBanner}
-	size = getSizes(request)
-	if size != "300x250,320x50" {
-		t.Errorf("%v does not match size.", multiFormatBanner)
+	var body adgRequestBody
+	assert.NoError(t, json.Unmarshal(requests[0].Body, &body))
+	assert.Equal(t, 0, body.Imark, "native request must not set imark")
+}
+
+func TestBuildRequestRejectsBadExt(t *testing.T) {
+	adg := newTestAdapter(t)
+	req := &openrtb2.BidRequest{
+		ID: "test",
+		Imp: []openrtb2.Imp{
+			{ID: "imp-bad", Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}}, Ext: json.RawMessage(`{"bidder":{"_id":"58278"}}`)},
+			{ID: "imp-ok", Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}}, Ext: json.RawMessage(`{"bidder":{"id":"58278"}}`)},
+		},
 	}
-	request = &openrtb2.Imp{Banner: noFormatBanner}
-	size = getSizes(request)
-	if size != "" {
-		t.Errorf("%v does not match size.", noFormatBanner)
-	}
-	request = &openrtb2.Imp{Native: nativeFormat}
-	size = getSizes(request)
-	if size != "" {
-		t.Errorf("%v does not match size.", nativeFormat)
-	}
+	requests, errs := adg.MakeRequests(req, &adapters.ExtraRequestInfo{})
+	assert.Len(t, errs, 1)
+	assert.Len(t, requests, 1, "valid imp should still produce a request")
 }
 
 func TestGetCurrency(t *testing.T) {
-	bidder, buildErr := Builder(openrtb_ext.BidderAdgeneration, config.Adapter{
-		Endpoint: "https://d.socdm.com/adsv/v1"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
-
-	if buildErr != nil {
-		t.Fatalf("Builder returned unexpected error %v", buildErr)
+	adg := newTestAdapter(t)
+	cases := []struct {
+		name string
+		cur  []string
+		want string
+	}{
+		{"default when empty", nil, "JPY"},
+		{"prefers JPY when supported", []string{"USD", "JPY"}, "JPY"},
+		{"falls back to first when JPY missing", []string{"USD", "EUR"}, "USD"},
 	}
-
-	bidderAdgeneration, _ := bidder.(*AdgenerationAdapter)
-
-	// Test items
-	var request *openrtb2.BidRequest
-	var currency string
-	innerDefaultCur := []string{"USD", "JPY"}
-	usdCur := []string{"USD", "EUR"}
-
-	request = &openrtb2.BidRequest{Cur: innerDefaultCur}
-	currency = bidderAdgeneration.getCurrency(request)
-	if currency != "JPY" {
-		t.Errorf("%v does not match currency.", innerDefaultCur)
-	}
-	request = &openrtb2.BidRequest{Cur: usdCur}
-	currency = bidderAdgeneration.getCurrency(request)
-	if currency != "USD" {
-		t.Errorf("%v does not match currency.", usdCur)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := adg.getCurrency(&openrtb2.BidRequest{Cur: c.cur})
+			assert.Equal(t, c.want, got)
+		})
 	}
 }
 
-func TestCreateAd(t *testing.T) {
-	// Test items
-	adgBannerImpId := "test-banner-imp"
-	adgBannerResponse := adgServerResponse{
-		Ad:         "<!DOCTYPE html>\n<head>\n<meta charset=\"UTF-8\">\n<script src=\"test.com\"></script>\n<body>\n<div id=\"medibasspContainer\">\n<iframe src=\"https://dummy-iframe.com></iframe>\n</div>\n</body>\n",
-		Beacon:     "<img src=\"https://dummy-beacon.com\">",
-		Beaconurl:  "https://dummy-beacon.com",
-		Cpm:        50,
-		Creativeid: "DummyDsp_SdkTeam_supership.jp",
-		H:          300,
-		W:          250,
-		Ttl:        10,
-		LandingUrl: "",
-		Scheduleid: "111111",
+func TestBuildAdMarkupBanner(t *testing.T) {
+	adResult := &adgResult{
+		Ad:        "<!DOCTYPE html><body><div id=\"x\"></div></body>",
+		Beacon:    "<img src=\"https://b.example/\">",
+		Beaconurl: "https://b.example/",
+		Cpm:       50,
 	}
-	matchBannerTag := "<div id=\"medibasspContainer\">\n<iframe src=\"https://dummy-iframe.com></iframe>\n</div>\n<img src=\"https://dummy-beacon.com\">"
+	imp := &openrtb2.Imp{ID: "imp-1", Banner: &openrtb2.Banner{}}
 
-	adgVastImpId := "test-vast-imp"
-	adgVastResponse := adgServerResponse{
-		Ad:         "<!DOCTYPE html>\n<head>\n<meta charset=\"UTF-8\">\n<script src=\"test.com\"></script>\n<body>\n<div id=\"medibasspContainer\">\n<iframe src=\"https://dummy-iframe.com></iframe>\n</div>\n</body>\n",
-		Beacon:     "<img src=\"https://dummy-beacon.com\">",
-		Beaconurl:  "https://dummy-beacon.com",
-		Cpm:        50,
-		Creativeid: "DummyDsp_SdkTeam_supership.jp",
-		H:          300,
-		W:          250,
-		Ttl:        10,
-		LandingUrl: "",
-		Vastxml:    "<?xml version=\"1.0\"><VAST version=\"3.0\"</VAST>",
-		Scheduleid: "111111",
-	}
-	matchVastTag := "<div id=\"apvad-test-vast-imp\"></div><script type=\"text/javascript\" id=\"apv\" src=\"https://cdn.apvdr.com/js/VideoAd.min.js\"></script><script type=\"text/javascript\"> (function(){ new APV.VideoAd({s:\"test-vast-imp\"}).load('<?xml version=\"1.0\"><VAST version=\"3.0\"</VAST>'); })(); </script><img src=\"https://dummy-beacon.com\">"
-
-	bannerAd := createAd(&adgBannerResponse, adgBannerImpId)
-	if bannerAd != matchBannerTag {
-		t.Errorf("%v does not match createAd.", adgBannerResponse)
-	}
-	vastAd := createAd(&adgVastResponse, adgVastImpId)
-	if vastAd != matchVastTag {
-		t.Errorf("%v does not match createAd.", adgVastResponse)
-	}
+	bidType, adm, err := buildAdMarkup(adResult, nil, imp)
+	assert.NoError(t, err)
+	assert.Equal(t, openrtb_ext.BidTypeBanner, bidType)
+	assert.Equal(t, "<div id=\"x\"></div><img src=\"https://b.example/\">", adm)
 }
 
-func TestMakeBids(t *testing.T) {
-	bidder, buildErr := Builder(openrtb_ext.BidderAdgeneration, config.Adapter{
-		Endpoint: "https://d.socdm.com/adsv/v1"}, config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
-
-	if buildErr != nil {
-		t.Fatalf("Builder returned unexpected error %v", buildErr)
+func TestBuildAdMarkupVastUsesAPV(t *testing.T) {
+	adResult := &adgResult{
+		Ad:      "<!DOCTYPE html><body></body>",
+		Beacon:  "<img src=\"https://b.example/\">",
+		Vastxml: "<VAST/>",
 	}
+	imp := &openrtb2.Imp{ID: "imp-vast", Banner: &openrtb2.Banner{}}
+	bidType, adm, err := buildAdMarkup(adResult, nil, imp)
+	assert.NoError(t, err)
+	assert.Equal(t, openrtb_ext.BidTypeBanner, bidType)
+	assert.Contains(t, adm, "apvad-imp-vast")
+	assert.Contains(t, adm, "cdn.apvdr.com/js/VideoAd.min.js")
+}
 
-	bidderAdgeneration, _ := bidder.(*AdgenerationAdapter)
+func TestBuildAdMarkupVastUsesADGBrowserMOnUpperBillboard(t *testing.T) {
+	adResult := &adgResult{
+		Ad:      "<!DOCTYPE html><body></body>",
+		Beacon:  "<img src=\"https://b.example/\">",
+		Vastxml: "<VAST/>",
+	}
+	loc := &adgLocationParams{Option: &adgLocationOption{AdType: "upper_billboard"}}
+	imp := &openrtb2.Imp{ID: "imp-ub", Banner: &openrtb2.Banner{}}
+	bidType, adm, err := buildAdMarkup(adResult, loc, imp)
+	assert.NoError(t, err)
+	assert.Equal(t, openrtb_ext.BidTypeBanner, bidType)
+	assert.Contains(t, adm, "adg-browser-m.js")
+	assert.NotContains(t, adm, "apvad-")
+}
+
+func TestBuildAdMarkupNative(t *testing.T) {
+	rawNative := json.RawMessage(`{"assets":[{"id":1,"title":{"text":"hello"}}],"link":{"url":"https://l.example/"}}`)
+	adResult := &adgResult{Native: rawNative}
+	imp := &openrtb2.Imp{ID: "imp-native", Native: &openrtb2.Native{Request: `{}`}}
+
+	bidType, adm, err := buildAdMarkup(adResult, nil, imp)
+	assert.NoError(t, err)
+	assert.Equal(t, openrtb_ext.BidTypeNative, bidType)
+	assert.True(t, strings.HasPrefix(adm, `{"native":`))
+	assert.Contains(t, adm, `"assets"`)
+}
+
+func TestMakeBidsReadsResultsAndAdomain(t *testing.T) {
+	adg := newTestAdapter(t)
 
 	internalRequest := &openrtb2.BidRequest{
-		ID: "test-success-bid-request",
+		ID: "test",
 		Imp: []openrtb2.Imp{
-			{ID: "bidRequest-success-test", Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}}, Ext: json.RawMessage(`{"bidder": { "id": "58278" }}`)},
+			{ID: "imp-1", Banner: &openrtb2.Banner{Format: []openrtb2.Format{{W: 300, H: 250}}}, Ext: json.RawMessage(`{"bidder":{"id":"58278"}}`)},
 		},
-		Device: &openrtb2.Device{UA: "testUA", IP: "testIP"},
-		Site:   &openrtb2.Site{Page: "https://supership.com"},
-		User:   &openrtb2.User{BuyerUID: "buyerID"},
 	}
-	externalRequest := adapters.RequestData{}
-	response := adapters.ResponseData{
-		StatusCode: 200,
-		Body:       ([]byte)("{\n \"ad\": \"testAd\",\n \"cpm\": 30,\n \"creativeid\": \"Dummy_supership.jp\",\n \"h\": 250,\n \"locationid\": \"58278\",\n \"results\": [{}],\n \"dealid\": \"test-deal-id\",\n \"w\": 300\n }"),
-	}
-	// default Currency InternalRequest
-	defaultCurBidderResponse, errs := bidder.MakeBids(internalRequest, &externalRequest, &response)
-	if len(errs) > 0 {
-		t.Errorf("MakeBids return errors. errors: %v", errs)
-	}
-	checkBidResponse(t, defaultCurBidderResponse, bidderAdgeneration.defaultCurrency)
+	respBody := `{
+		"locationid": "58278",
+		"results": [{
+			"ad": "<body>testAd</body>",
+			"beacon": "",
+			"cpm": 30,
+			"creativeid": "Dummy_supership.jp",
+			"dealid": "test-deal",
+			"h": 250,
+			"w": 300,
+			"adomain": ["advertiser.example"]
+		}]
+	}`
+	resp := &adapters.ResponseData{StatusCode: 200, Body: []byte(respBody)}
 
-	// Specified Currency InternalRequest
-	usdCur := "USD"
-	internalRequest.Cur = []string{usdCur}
-	specifiedCurBidderResponse, errs := bidder.MakeBids(internalRequest, &externalRequest, &response)
-	if len(errs) > 0 {
-		t.Errorf("MakeBids return errors. errors: %v", errs)
-	}
-	checkBidResponse(t, specifiedCurBidderResponse, usdCur)
+	bidderResp, errs := adg.MakeBids(internalRequest, &adapters.RequestData{}, resp)
+	assert.Empty(t, errs)
+	assert.NotNil(t, bidderResp)
+	assert.Equal(t, "JPY", bidderResp.Currency)
+	assert.Len(t, bidderResp.Bids, 1)
 
+	bid := bidderResp.Bids[0]
+	assert.Equal(t, openrtb_ext.BidTypeBanner, bid.BidType)
+	assert.Equal(t, "58278", bid.Bid.ID)
+	assert.Equal(t, "imp-1", bid.Bid.ImpID)
+	assert.Equal(t, "testAd", bid.Bid.AdM)
+	assert.Equal(t, 30.0, bid.Bid.Price)
+	assert.Equal(t, int64(300), bid.Bid.W)
+	assert.Equal(t, int64(250), bid.Bid.H)
+	assert.Equal(t, "Dummy_supership.jp", bid.Bid.CrID)
+	assert.Equal(t, "test-deal", bid.Bid.DealID)
+	assert.Equal(t, []string{"advertiser.example"}, bid.Bid.ADomain)
 }
 
-func checkBidResponse(t *testing.T, bidderResponse *adapters.BidderResponse, expectedCurrency string) {
-	if bidderResponse == nil {
-		t.Errorf("actual bidResponse is nil.")
-	}
+func TestMakeBidsReturnsNilOnNoContent(t *testing.T) {
+	adg := newTestAdapter(t)
+	resp := &adapters.ResponseData{StatusCode: http.StatusNoContent}
+	bidderResp, errs := adg.MakeBids(&openrtb2.BidRequest{}, &adapters.RequestData{}, resp)
+	assert.Nil(t, bidderResp)
+	assert.Empty(t, errs)
+}
 
-	// AdM is assured by TestCreateAd and JSON tests
-	var expectedAdM string = "testAd"
-	var expectedID string = "58278"
-	var expectedImpID = "bidRequest-success-test"
-	var expectedPrice float64 = 30.0
-	var expectedW int64 = 300
-	var expectedH int64 = 250
-	var expectedCrID string = "Dummy_supership.jp"
-	var extectedDealID string = "test-deal-id"
-
-	//nolint: staticcheck // false positive SA5011: possible nil pointer dereference
-	assert.Equal(t, expectedCurrency, bidderResponse.Currency)
-	assert.Equal(t, 1, len(bidderResponse.Bids))
-	assert.Equal(t, expectedID, bidderResponse.Bids[0].Bid.ID)
-	assert.Equal(t, expectedImpID, bidderResponse.Bids[0].Bid.ImpID)
-	assert.Equal(t, expectedAdM, bidderResponse.Bids[0].Bid.AdM)
-	assert.Equal(t, expectedPrice, bidderResponse.Bids[0].Bid.Price)
-	assert.Equal(t, expectedW, bidderResponse.Bids[0].Bid.W)
-	assert.Equal(t, expectedH, bidderResponse.Bids[0].Bid.H)
-	assert.Equal(t, expectedCrID, bidderResponse.Bids[0].Bid.CrID)
-	assert.Equal(t, extectedDealID, bidderResponse.Bids[0].Bid.DealID)
+func TestMakeBidsReturnsErrorOn400(t *testing.T) {
+	adg := newTestAdapter(t)
+	resp := &adapters.ResponseData{StatusCode: http.StatusBadRequest}
+	bidderResp, errs := adg.MakeBids(&openrtb2.BidRequest{}, &adapters.RequestData{}, resp)
+	assert.Nil(t, bidderResp)
+	assert.Len(t, errs, 1)
 }

--- a/adapters/adgeneration/adgeneration_test.go
+++ b/adapters/adgeneration/adgeneration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prebid/openrtb/v20/openrtb2"
 	"github.com/prebid/prebid-server/v4/adapters"
+	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
 	"github.com/stretchr/testify/assert"
@@ -26,11 +27,13 @@ func newTestAdapter(t *testing.T) *AdgenerationAdapter {
 	return bidder.(*AdgenerationAdapter)
 }
 
-// 注: adgenerationtest/ 配下の JSON golden file は GET 形式の旧仕様で作成されている。
-// Prebid.js パリティ移行 (POST + JSON Body) に伴い書き換えが必要。
-// 詳細: projects/prebid-server/research/parity-concerns.md §13
 func TestJsonSamples(t *testing.T) {
-	t.Skip("TODO: regenerate adgenerationtest/ JSON golden files for POST + JSON body format")
+	bidder, err := Builder(openrtb_ext.BidderAdgeneration, config.Adapter{Endpoint: testEndpoint},
+		config.Server{ExternalUrl: "http://hosturl.com", GvlID: 1, DataCenter: "2"})
+	if err != nil {
+		t.Fatalf("Builder returned unexpected error: %v", err)
+	}
+	adapterstest.RunJSONBidderTest(t, "adgenerationtest", bidder)
 }
 
 func TestBuildRequestPostsToAdgenPrebid(t *testing.T) {

--- a/adapters/adgeneration/adgeneration_test.go
+++ b/adapters/adgeneration/adgeneration_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
+	"github.com/prebid/prebid-server/v4/util/ptrutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -307,6 +308,48 @@ func TestBuildAdMarkupADGBrowserMStripsNewlines(t *testing.T) {
 	// (adm に生の "<VAST" が残ると Prebid Mobile iOS が VAST と誤判定するため)。
 	assert.Contains(t, adm, "vastXml: decodeURIComponent('%3CVAST%3Efoo%3C%2FVAST%3E')")
 	assert.NotContains(t, adm, "<VAST>")
+}
+
+// imp が video を宣言している場合は VAST を生のまま video bid として返す
+// (Prebid Mobile の video ad unit はレンダリングを SDK 内蔵プレイヤーが行うため、
+// ブラウザ用 JS プレイヤー (ADGBrowserM/APV) のラッパーは不要)。
+func TestBuildAdMarkupVastReturnsRawVideoWhenImpHasVideo(t *testing.T) {
+	adResult := &adgResult{
+		Ad:      "<!DOCTYPE html><body></body>",
+		Vastxml: "<VAST version=\"3.0\"><Ad/></VAST>",
+	}
+	// upper_billboard 指定でも imp.video が優先される
+	loc := &adgLocationParams{Option: &adgLocationOption{AdType: "upper_billboard"}}
+	imp := &openrtb2.Imp{ID: "imp-video", Video: &openrtb2.Video{W: ptrutil.ToPtr[int64](640), H: ptrutil.ToPtr[int64](360)}}
+	bidType, adm, err := buildAdMarkup(adResult, loc, imp)
+	assert.NoError(t, err)
+	assert.Equal(t, openrtb_ext.BidTypeVideo, bidType)
+	assert.Equal(t, "<VAST version=\"3.0\"><Ad/></VAST>", adm)
+}
+
+// banner と video の両方を持つ imp でも vastxml があれば video を優先する。
+func TestBuildAdMarkupVastPrefersVideoOnMultiFormatImp(t *testing.T) {
+	adResult := &adgResult{
+		Ad:      "<!DOCTYPE html><body></body>",
+		Vastxml: "<VAST/>",
+	}
+	imp := &openrtb2.Imp{ID: "imp-multi", Banner: &openrtb2.Banner{}, Video: &openrtb2.Video{}}
+	bidType, adm, err := buildAdMarkup(adResult, nil, imp)
+	assert.NoError(t, err)
+	assert.Equal(t, openrtb_ext.BidTypeVideo, bidType)
+	assert.Equal(t, "<VAST/>", adm)
+}
+
+// vastxml が無ければ imp.video があっても通常の banner (Ad) を返す。
+func TestBuildAdMarkupVideoImpWithoutVastFallsBackToBanner(t *testing.T) {
+	adResult := &adgResult{
+		Ad: "<!DOCTYPE html><body><p>banner</p></body>",
+	}
+	imp := &openrtb2.Imp{ID: "imp-video", Video: &openrtb2.Video{}}
+	bidType, adm, err := buildAdMarkup(adResult, nil, imp)
+	assert.NoError(t, err)
+	assert.Equal(t, openrtb_ext.BidTypeBanner, bidType)
+	assert.Contains(t, adm, "banner")
 }
 
 func TestBuildAdMarkupVastUsesADGBrowserMOnUpperBillboard(t *testing.T) {

--- a/adapters/adgeneration/adgeneration_test.go
+++ b/adapters/adgeneration/adgeneration_test.go
@@ -124,6 +124,104 @@ func TestBuildRequestRejectsBadExt(t *testing.T) {
 	assert.Len(t, requests, 1, "valid imp should still produce a request")
 }
 
+// TestDetectSdkType は channel + device.os から sdktype を導出する挙動を網羅する。
+// バックエンド `/adgen/prebid` が sdktype で配信ロジックを切り替える前提。
+func TestDetectSdkType(t *testing.T) {
+	cases := []struct {
+		name string
+		req  *openrtb2.BidRequest
+		want string
+	}{
+		{
+			name: "web: channel=pbjs / site only",
+			req: &openrtb2.BidRequest{
+				Ext:  json.RawMessage(`{"prebid":{"channel":{"name":"pbjs","version":"9"}}}`),
+				Site: &openrtb2.Site{Page: "https://example.com/"},
+			},
+			want: "0",
+		},
+		{
+			name: "web: channel=amp",
+			req: &openrtb2.BidRequest{
+				Ext:  json.RawMessage(`{"prebid":{"channel":{"name":"amp"}}}`),
+				Site: &openrtb2.Site{Page: "https://example.com/"},
+			},
+			want: "0",
+		},
+		{
+			name: "mobile app android via channel",
+			req: &openrtb2.BidRequest{
+				Ext:    json.RawMessage(`{"prebid":{"channel":{"name":"app"}}}`),
+				App:    &openrtb2.App{Bundle: "com.example.app"},
+				Device: &openrtb2.Device{OS: "android"},
+			},
+			want: "1",
+		},
+		{
+			name: "mobile app ios via channel (case insensitive)",
+			req: &openrtb2.BidRequest{
+				Ext:    json.RawMessage(`{"prebid":{"channel":{"name":"APP"}}}`),
+				App:    &openrtb2.App{Bundle: "com.example.app"},
+				Device: &openrtb2.Device{OS: "iOS"},
+			},
+			want: "2",
+		},
+		{
+			name: "fallback: channel 不在で BidRequest.App のみ (android)",
+			req: &openrtb2.BidRequest{
+				App:    &openrtb2.App{Bundle: "com.example.app"},
+				Device: &openrtb2.Device{OS: "android"},
+			},
+			want: "1",
+		},
+		{
+			name: "fallback: channel 不在で BidRequest.App のみ (ios)",
+			req: &openrtb2.BidRequest{
+				App:    &openrtb2.App{Bundle: "com.example.app"},
+				Device: &openrtb2.Device{OS: "ios"},
+			},
+			want: "2",
+		},
+		{
+			name: "app context だが device.os 不明 → 0",
+			req: &openrtb2.BidRequest{
+				Ext:    json.RawMessage(`{"prebid":{"channel":{"name":"app"}}}`),
+				App:    &openrtb2.App{Bundle: "com.example.app"},
+				Device: &openrtb2.Device{OS: "tvos"},
+			},
+			want: "0",
+		},
+		{
+			name: "app と site が両方 nil → web 扱い",
+			req:  &openrtb2.BidRequest{},
+			want: "0",
+		},
+		{
+			name: "app + site 両方ある場合は channel 優先 (channel=app)",
+			req: &openrtb2.BidRequest{
+				Ext:    json.RawMessage(`{"prebid":{"channel":{"name":"app"}}}`),
+				App:    &openrtb2.App{Bundle: "com.example.app"},
+				Site:   &openrtb2.Site{Page: "https://example.com/"},
+				Device: &openrtb2.Device{OS: "android"},
+			},
+			want: "1",
+		},
+		{
+			name: "壊れた ext は channel 不在として扱う (= site があれば web)",
+			req: &openrtb2.BidRequest{
+				Ext:  json.RawMessage(`{not-json`),
+				Site: &openrtb2.Site{Page: "https://example.com/"},
+			},
+			want: "0",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, detectSdkType(c.req))
+		})
+	}
+}
+
 // TestGetCurrency は Prebid.js (adgenerationBidAdapter.js: getCurrencyType) と同じ
 // 二択挙動: USD を含めば USD、それ以外は JPY。
 func TestGetCurrency(t *testing.T) {

--- a/adapters/adgeneration/adgeneration_test.go
+++ b/adapters/adgeneration/adgeneration_test.go
@@ -287,7 +287,10 @@ func TestBuildAdMarkupVastStripsNewlinesInsideJsLiteral(t *testing.T) {
 	// APV.VideoAd(...).load('...') の引数内に改行が残ると JS 文字列が壊れる。
 	assert.NotContains(t, adm, "load('<VAST>\r\nfoo")
 	assert.NotContains(t, adm, "load('<VAST>\nfoo")
-	assert.Contains(t, adm, "load('<VAST>foobar</VAST>')")
+	// VAST は percent-encoding して decodeURIComponent で復元する
+	// (adm に生の "<VAST" が残ると Prebid Mobile iOS が VAST と誤判定するため)。
+	assert.Contains(t, adm, "load(decodeURIComponent('%3CVAST%3Efoobar%3C%2FVAST%3E'))")
+	assert.NotContains(t, adm, "<VAST>")
 }
 
 func TestBuildAdMarkupADGBrowserMStripsNewlines(t *testing.T) {
@@ -300,7 +303,10 @@ func TestBuildAdMarkupADGBrowserMStripsNewlines(t *testing.T) {
 	_, adm, err := buildAdMarkup(adResult, loc, imp)
 	assert.NoError(t, err)
 	assert.NotContains(t, adm, "vastXml: '<VAST>\r\nfoo")
-	assert.Contains(t, adm, "vastXml: '<VAST>foo</VAST>'")
+	// VAST は percent-encoding して decodeURIComponent で復元する
+	// (adm に生の "<VAST" が残ると Prebid Mobile iOS が VAST と誤判定するため)。
+	assert.Contains(t, adm, "vastXml: decodeURIComponent('%3CVAST%3Efoo%3C%2FVAST%3E')")
+	assert.NotContains(t, adm, "<VAST>")
 }
 
 func TestBuildAdMarkupVastUsesADGBrowserMOnUpperBillboard(t *testing.T) {

--- a/adapters/adgeneration/adgeneration_test.go
+++ b/adapters/adgeneration/adgeneration_test.go
@@ -124,6 +124,8 @@ func TestBuildRequestRejectsBadExt(t *testing.T) {
 	assert.Len(t, requests, 1, "valid imp should still produce a request")
 }
 
+// TestGetCurrency は Prebid.js (adgenerationBidAdapter.js: getCurrencyType) と同じ
+// 二択挙動: USD を含めば USD、それ以外は JPY。
 func TestGetCurrency(t *testing.T) {
 	adg := newTestAdapter(t)
 	cases := []struct {
@@ -131,9 +133,12 @@ func TestGetCurrency(t *testing.T) {
 		cur  []string
 		want string
 	}{
-		{"default when empty", nil, "JPY"},
-		{"prefers JPY when supported", []string{"USD", "JPY"}, "JPY"},
-		{"falls back to first when JPY missing", []string{"USD", "EUR"}, "USD"},
+		{"default JPY when empty", nil, "JPY"},
+		{"USD wins over JPY", []string{"USD", "JPY"}, "USD"},
+		{"USD only", []string{"USD"}, "USD"},
+		{"unrelated currency falls back to JPY", []string{"EUR"}, "JPY"},
+		{"JPY only", []string{"JPY"}, "JPY"},
+		{"case-insensitive usd", []string{"usd"}, "USD"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -170,6 +175,34 @@ func TestBuildAdMarkupVastUsesAPV(t *testing.T) {
 	assert.Equal(t, openrtb_ext.BidTypeBanner, bidType)
 	assert.Contains(t, adm, "apvad-imp-vast")
 	assert.Contains(t, adm, "cdn.apvdr.com/js/VideoAd.min.js")
+}
+
+// vastxml に含まれる改行が JS 文字列リテラル内に残らないこと (Prebid.js: /\r?\n/g 相当)。
+func TestBuildAdMarkupVastStripsNewlinesInsideJsLiteral(t *testing.T) {
+	adResult := &adgResult{
+		Ad:      "<!DOCTYPE html><body></body>",
+		Vastxml: "<VAST>\r\nfoo\nbar\n</VAST>",
+	}
+	imp := &openrtb2.Imp{ID: "imp-vast", Banner: &openrtb2.Banner{}}
+	_, adm, err := buildAdMarkup(adResult, nil, imp)
+	assert.NoError(t, err)
+	// APV.VideoAd(...).load('...') の引数内に改行が残ると JS 文字列が壊れる。
+	assert.NotContains(t, adm, "load('<VAST>\r\nfoo")
+	assert.NotContains(t, adm, "load('<VAST>\nfoo")
+	assert.Contains(t, adm, "load('<VAST>foobar</VAST>')")
+}
+
+func TestBuildAdMarkupADGBrowserMStripsNewlines(t *testing.T) {
+	adResult := &adgResult{
+		Ad:      "<!DOCTYPE html><body></body>",
+		Vastxml: "<VAST>\r\nfoo\n</VAST>",
+	}
+	loc := &adgLocationParams{Option: &adgLocationOption{AdType: "upper_billboard"}}
+	imp := &openrtb2.Imp{ID: "imp-ub", Banner: &openrtb2.Banner{}}
+	_, adm, err := buildAdMarkup(adResult, loc, imp)
+	assert.NoError(t, err)
+	assert.NotContains(t, adm, "vastXml: '<VAST>\r\nfoo")
+	assert.Contains(t, adm, "vastXml: '<VAST>foo</VAST>'")
 }
 
 func TestBuildAdMarkupVastUsesADGBrowserMOnUpperBillboard(t *testing.T) {
@@ -239,6 +272,31 @@ func TestBuildAdMarkupNativeBeaconUrlDeduplicated(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(adm, "https://tg.example/bc"))
 }
 
+// Prebid.js isNative() 互換: assets が空/欠落なら native ではなく banner として扱う。
+func TestBuildAdMarkupFallsBackToBannerWhenNativeAssetsMissing(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"empty assets", `{"assets":[],"link":{"url":"https://l.example/"}}`},
+		{"no assets key", `{"link":{"url":"https://l.example/"}}`},
+		{"wrapped empty assets", `{"native":{"assets":[]}}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			adResult := &adgResult{
+				Native: json.RawMessage(c.raw),
+				Ad:     "<body>fallback banner</body>",
+			}
+			imp := &openrtb2.Imp{ID: "imp-native", Native: &openrtb2.Native{Request: `{}`}}
+			bidType, adm, err := buildAdMarkup(adResult, nil, imp)
+			assert.NoError(t, err)
+			assert.Equal(t, openrtb_ext.BidTypeBanner, bidType)
+			assert.Equal(t, "fallback banner", adm)
+		})
+	}
+}
+
 func TestBuildAdMarkupNativeAcceptsWrappedInput(t *testing.T) {
 	rawNative := json.RawMessage(`{"native":{"assets":[{"id":1,"title":{"text":"hi"}}]}}`)
 	adResult := &adgResult{Native: rawNative, Beaconurl: "https://tg.example/bc"}
@@ -276,7 +334,8 @@ func TestMakeBidsReadsResultsAndAdomain(t *testing.T) {
 	}`
 	resp := &adapters.ResponseData{StatusCode: 200, Body: []byte(respBody)}
 
-	bidderResp, errs := adg.MakeBids(internalRequest, &adapters.RequestData{}, resp)
+	sentBody, _ := json.Marshal(adgRequestBody{Ortb: openrtb2.BidRequest{Imp: []openrtb2.Imp{{ID: "imp-1"}}}})
+	bidderResp, errs := adg.MakeBids(internalRequest, &adapters.RequestData{Body: sentBody}, resp)
 	assert.Empty(t, errs)
 	assert.NotNil(t, bidderResp)
 	assert.Equal(t, "JPY", bidderResp.Currency)

--- a/adapters/adgeneration/adgeneration_test.go
+++ b/adapters/adgeneration/adgeneration_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prebid/prebid-server/v4/adapters/adapterstest"
 	"github.com/prebid/prebid-server/v4/config"
 	"github.com/prebid/prebid-server/v4/openrtb_ext"
-	"github.com/prebid/prebid-server/v4/util/ptrutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -308,48 +307,6 @@ func TestBuildAdMarkupADGBrowserMStripsNewlines(t *testing.T) {
 	// (adm に生の "<VAST" が残ると Prebid Mobile iOS が VAST と誤判定するため)。
 	assert.Contains(t, adm, "vastXml: decodeURIComponent('%3CVAST%3Efoo%3C%2FVAST%3E')")
 	assert.NotContains(t, adm, "<VAST>")
-}
-
-// imp が video を宣言している場合は VAST を生のまま video bid として返す
-// (Prebid Mobile の video ad unit はレンダリングを SDK 内蔵プレイヤーが行うため、
-// ブラウザ用 JS プレイヤー (ADGBrowserM/APV) のラッパーは不要)。
-func TestBuildAdMarkupVastReturnsRawVideoWhenImpHasVideo(t *testing.T) {
-	adResult := &adgResult{
-		Ad:      "<!DOCTYPE html><body></body>",
-		Vastxml: "<VAST version=\"3.0\"><Ad/></VAST>",
-	}
-	// upper_billboard 指定でも imp.video が優先される
-	loc := &adgLocationParams{Option: &adgLocationOption{AdType: "upper_billboard"}}
-	imp := &openrtb2.Imp{ID: "imp-video", Video: &openrtb2.Video{W: ptrutil.ToPtr[int64](640), H: ptrutil.ToPtr[int64](360)}}
-	bidType, adm, err := buildAdMarkup(adResult, loc, imp)
-	assert.NoError(t, err)
-	assert.Equal(t, openrtb_ext.BidTypeVideo, bidType)
-	assert.Equal(t, "<VAST version=\"3.0\"><Ad/></VAST>", adm)
-}
-
-// banner と video の両方を持つ imp でも vastxml があれば video を優先する。
-func TestBuildAdMarkupVastPrefersVideoOnMultiFormatImp(t *testing.T) {
-	adResult := &adgResult{
-		Ad:      "<!DOCTYPE html><body></body>",
-		Vastxml: "<VAST/>",
-	}
-	imp := &openrtb2.Imp{ID: "imp-multi", Banner: &openrtb2.Banner{}, Video: &openrtb2.Video{}}
-	bidType, adm, err := buildAdMarkup(adResult, nil, imp)
-	assert.NoError(t, err)
-	assert.Equal(t, openrtb_ext.BidTypeVideo, bidType)
-	assert.Equal(t, "<VAST/>", adm)
-}
-
-// vastxml が無ければ imp.video があっても通常の banner (Ad) を返す。
-func TestBuildAdMarkupVideoImpWithoutVastFallsBackToBanner(t *testing.T) {
-	adResult := &adgResult{
-		Ad: "<!DOCTYPE html><body><p>banner</p></body>",
-	}
-	imp := &openrtb2.Imp{ID: "imp-video", Video: &openrtb2.Video{}}
-	bidType, adm, err := buildAdMarkup(adResult, nil, imp)
-	assert.NoError(t, err)
-	assert.Equal(t, openrtb_ext.BidTypeBanner, bidType)
-	assert.Contains(t, adm, "banner")
 }
 
 func TestBuildAdMarkupVastUsesADGBrowserMOnUpperBillboard(t *testing.T) {

--- a/adapters/adgeneration/adgeneration_test.go
+++ b/adapters/adgeneration/adgeneration_test.go
@@ -80,7 +80,7 @@ func TestBuildRequestPostsToAdgenPrebid(t *testing.T) {
 	assert.NoError(t, json.Unmarshal(r.Body, &body))
 	assert.Equal(t, "JPY", body.Currency)
 	assert.Equal(t, "prebidserver", body.Sdkname)
-	assert.Equal(t, "1.0.3", body.Adapterver)
+	assert.Equal(t, "1.6.6", body.Adapterver)
 	assert.Equal(t, 1, body.Imark, "banner request should set imark=1")
 	assert.NotEmpty(t, body.Pbver)
 	assert.Len(t, body.Ortb.Imp, 1)
@@ -185,6 +185,24 @@ func TestBuildAdMarkupVastUsesADGBrowserMOnUpperBillboard(t *testing.T) {
 	assert.Equal(t, openrtb_ext.BidTypeBanner, bidType)
 	assert.Contains(t, adm, "adg-browser-m.js")
 	assert.NotContains(t, adm, "apvad-")
+	// marginTop 未指定時は Prebid.js と同じく '0' を埋める。
+	assert.Contains(t, adm, "marginTop: '0'")
+}
+
+func TestBuildAdMarkupVastADGBrowserMUsesBidderMarginTop(t *testing.T) {
+	adResult := &adgResult{
+		Ad:      "<!DOCTYPE html><body></body>",
+		Vastxml: "<VAST/>",
+	}
+	loc := &adgLocationParams{Option: &adgLocationOption{AdType: "upper_billboard"}}
+	imp := &openrtb2.Imp{
+		ID:     "imp-ub",
+		Banner: &openrtb2.Banner{},
+		Ext:    json.RawMessage(`{"bidder":{"id":"58278","marginTop":"42"}}`),
+	}
+	_, adm, err := buildAdMarkup(adResult, loc, imp)
+	assert.NoError(t, err)
+	assert.Contains(t, adm, "marginTop: '42'")
 }
 
 func TestBuildAdMarkupNative(t *testing.T) {
@@ -197,6 +215,41 @@ func TestBuildAdMarkupNative(t *testing.T) {
 	assert.Equal(t, openrtb_ext.BidTypeNative, bidType)
 	assert.True(t, strings.HasPrefix(adm, `{"native":`))
 	assert.Contains(t, adm, `"assets"`)
+}
+
+func TestBuildAdMarkupNativeAppendsBeaconUrlToImptrackers(t *testing.T) {
+	rawNative := json.RawMessage(`{"assets":[{"id":1,"title":{"text":"hello"}}],"link":{"url":"https://l.example/"},"imptrackers":["https://existing.example/imp"]}`)
+	adResult := &adgResult{Native: rawNative, Beaconurl: "https://tg.example/bc"}
+	imp := &openrtb2.Imp{ID: "imp-native", Native: &openrtb2.Native{Request: `{}`}}
+
+	_, adm, err := buildAdMarkup(adResult, nil, imp)
+	assert.NoError(t, err)
+	assert.Contains(t, adm, "https://existing.example/imp")
+	assert.Contains(t, adm, "https://tg.example/bc", "beaconurl must be appended to imptrackers")
+}
+
+func TestBuildAdMarkupNativeBeaconUrlDeduplicated(t *testing.T) {
+	rawNative := json.RawMessage(`{"assets":[{"id":1,"title":{"text":"hi"}}],"imptrackers":["https://tg.example/bc"]}`)
+	adResult := &adgResult{Native: rawNative, Beaconurl: "https://tg.example/bc"}
+	imp := &openrtb2.Imp{ID: "imp-native", Native: &openrtb2.Native{Request: `{}`}}
+
+	_, adm, err := buildAdMarkup(adResult, nil, imp)
+	assert.NoError(t, err)
+	// 既に imptrackers に含まれている場合は重複追加しない。
+	assert.Equal(t, 1, strings.Count(adm, "https://tg.example/bc"))
+}
+
+func TestBuildAdMarkupNativeAcceptsWrappedInput(t *testing.T) {
+	rawNative := json.RawMessage(`{"native":{"assets":[{"id":1,"title":{"text":"hi"}}]}}`)
+	adResult := &adgResult{Native: rawNative, Beaconurl: "https://tg.example/bc"}
+	imp := &openrtb2.Imp{ID: "imp-native", Native: &openrtb2.Native{Request: `{}`}}
+
+	_, adm, err := buildAdMarkup(adResult, nil, imp)
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(adm, `{"native":`))
+	// 入れ子 native を二重ラップしない (= 出力に "native" は 1 回しか現れない)。
+	assert.Equal(t, 1, strings.Count(adm, `"native"`))
+	assert.Contains(t, adm, "https://tg.example/bc")
 }
 
 func TestMakeBidsReadsResultsAndAdomain(t *testing.T) {

--- a/adapters/adgeneration/adgenerationtest/exemplary/single-banner-android.json
+++ b/adapters/adgeneration/adgenerationtest/exemplary/single-banner-android.json
@@ -1,5 +1,5 @@
 {
-    "mockBidRequest":{
+    "mockBidRequest": {
         "id": "some-request-id",
         "site": {
             "page": "http://example.com/test.html"
@@ -35,33 +35,49 @@
     },
     "httpCalls": [
         {
-            "internalRequest": {
-                "id": "some-request-id",
-                "site": {
-                    "page": "http://example.com/test.html"
-                },
-                "imp": [
-                    {
-                        "id": "some-impression-id",
-                        "banner": {
-                            "format": [
-                                {
-                                    "w": 300,
-                                    "h": 250
+            "expectedRequest": {
+                "uri": "https://d.socdm.com/adgen/prebid?id=58278&posall=SSPLOC&sdktype=0",
+                "body": {
+                    "currency": "JPY",
+                    "pbver": "unknown",
+                    "sdkname": "prebidserver",
+                    "adapterver": "1.0.3",
+                    "ortb": {
+                        "id": "some-request-id",
+                        "imp": [
+                            {
+                                "id": "some-impression-id",
+                                "banner": {
+                                    "format": [
+                                        {
+                                            "w": 300,
+                                            "h": 250
+                                        }
+                                    ]
+                                },
+                                "ext": {
+                                    "bidder": {
+                                        "id": "58278"
+                                    }
                                 }
-                            ]
-                        },
-                        "ext": {
-                            "bidder": {
-                                "id": "58278"
                             }
-                        }
-                    }
-                ],
-                "tmax": 500
-            },
-            "expectedRequest":{
-                "uri": "https://d.socdm.com/adsv/v1?adapterver=1.0.3&advertising_id=advertising_id&appname=adgneration&currency=JPY&hb=true&id=58278&posall=SSPLOC&sdkname=prebidserver&sdktype=1&sizes=300x250&t=json3&tp=http%3A%2F%2Fexample.com%2Ftest.html",
+                        ],
+                        "site": {
+                            "page": "http://example.com/test.html"
+                        },
+                        "app": {
+                            "name": "adgneration"
+                        },
+                        "device": {
+                            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36",
+                            "ip": "0.0.0.0",
+                            "os": "android",
+                            "ifa": "advertising_id"
+                        },
+                        "tmax": 500
+                    },
+                    "imark": 1
+                },
                 "headers": {
                     "Accept": [
                         "application/json"
@@ -76,92 +92,49 @@
                         "0.0.0.0"
                     ]
                 },
-                "impIDs":["some-impression-id"]
+                "impIDs": ["some-impression-id"]
             },
-            "mockResponse":{
+            "mockResponse": {
                 "status": 200,
                 "body": {
-                    "ad": "<!DOCTYPE html>\n  <head>\n    <meta charset=\"UTF-8\">\n    <script src=\"https:\/\/i.socdm.com\/sdk\/js\/adg-script-base.js\" type=\"text\/javascript\"><\/script>\n    <script type=\"text\/javascript\">\n      adsettings = {\n        locationid  : 58278,\n        rotation    : 0,\n        displaytype : 1,\n        sdktype     : \"0\",\n        scheduleid  : 512601\n      };\n    <\/script>\n    <style>\n      body {\n        margin:0;\n        padding:0;\n      }\n    <\/style>\n  <\/head>\n  <body>\n    <div id=\"medibasspContainer\">\n      <iframe src=\"https:\/\/s3-ap-northeast-1.amazonaws.com\/sdk-temp\/adg-sample-ad\/300x250.html?prc=-Cuepak&rd=https%3A%2F%2Ftg.socdm.com%2Frd%2Fv1%2Fz%2FhKFj2gDXY2hzbT0xOTgsZmJkZGMyNWEvNTgyNzgvU1NQTE9DLzUxMjYwMS83MjExNS43Njg1NS41MTI2MDEvMTA5MzkyNi82NDkxOS81ODI3ODpTU1BMT0M6Ki9jdD0xNTg1MjEyMDg1Nzg5O3NyPWh0dHBzO2RzcGlkPTMwMTtwcj16RGFfYVY0O3ByYj15UTtwcm89eVE7cHJvYz1KUFk7Y3JkMnk9MTA5LjQzMDAwMDAwMDAwMDAxO2NyeTJkPTAuMDA5MTM4MjYxOTAyNTg2MTI3MztpZHg9MDulc2VxaWTaACQ0NzFhM2JlNS1lYTQzLWRhZjAtYjhjZi1mNjJkNTA1N2Y5ZWOnc2VxdGltZa0xNTg1MjEyMDg1Nzg5pHh1aWS4WE52SVNNQ281bUlBQU1hN2dOUUFBQUFB%2Fp%2Fctsv%3Dm-ad226%3Bseqid%3D471a3be5-ea43-daf0-b8cf-f62d5057f9ec%3B%2Fg%2FU%3A%3Furl%3D\" style=\"border: 0px;\" width=\"300\" height=\"250\" frameborder=\"0\" scrolling=\"no\"><\/iframe>\n    <\/div>\n  <\/body>\n",
-                    "beacon": "<img src=\"https://tg.socdm.com/bc/v3?b=beaconID&amp;xuid=XUID&amp;ctsv=CTSV&amp;seqid=SeqID&amp;seqtime=SeqTime&amp;seqctx=SeqCtx&amp;t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
-                    "beaconurl": "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif",
-                    "cpm": 46.6,
-                    "creativeid": "Dummy_supership.jp",
-                    "displaytype": "1",
-                    "h": 250,
-                    "ids": {
-                        "anid": "",
-                        "diid": "",
-                        "idfa": "",
-                        "soc": "Soc"
-                    },
-                    "location_params": null,
                     "locationid": "58278",
                     "results": [
                         {
-                            "ad": "<!DOCTYPE html>\n  <head>\n    <meta charset=\"UTF-8\">\n    <script src=\"https:\/\/i.socdm.com\/sdk\/js\/adg-script-base.js\" type=\"text\/javascript\"><\/script>\n    <script type=\"text\/javascript\">\n      adsettings = {\n        locationid  : 58278,\n        rotation    : 0,\n        displaytype : 1,\n        sdktype     : \"0\",\n        scheduleid  : 512601\n      };\n    <\/script>\n    <style>\n      body {\n        margin:0;\n        padding:0;\n      }\n    <\/style>\n  <\/head>\n  <body>\n    <div id=\"medibasspContainer\">\n      <iframe src=\"https:\/\/s3-ap-northeast-1.amazonaws.com\/sdk-temp\/adg-sample-ad\/300x250.html?prc=-Cuepak&rd=https%3A%2F%2Ftg.socdm.com%2Frd%2Fv1%2Fz%2FhKFj2gDXY2hzbT0xOTgsZmJkZGMyNWEvNTgyNzgvU1NQTE9DLzUxMjYwMS83MjExNS43Njg1NS41MTI2MDEvMTA5MzkyNi82NDkxOS81ODI3ODpTU1BMT0M6Ki9jdD0xNTg1MjEyMDg1Nzg5O3NyPWh0dHBzO2RzcGlkPTMwMTtwcj16RGFfYVY0O3ByYj15UTtwcm89eVE7cHJvYz1KUFk7Y3JkMnk9MTA5LjQzMDAwMDAwMDAwMDAxO2NyeTJkPTAuMDA5MTM4MjYxOTAyNTg2MTI3MztpZHg9MDulc2VxaWTaACQ0NzFhM2JlNS1lYTQzLWRhZjAtYjhjZi1mNjJkNTA1N2Y5ZWOnc2VxdGltZa0xNTg1MjEyMDg1Nzg5pHh1aWS4WE52SVNNQ281bUlBQU1hN2dOUUFBQUFB%2Fp%2Fctsv%3Dm-ad226%3Bseqid%3D471a3be5-ea43-daf0-b8cf-f62d5057f9ec%3B%2Fg%2FU%3A%3Furl%3D\" style=\"border: 0px;\" width=\"300\" height=\"250\" frameborder=\"0\" scrolling=\"no\"><\/iframe>\n    <\/div>\n  <\/body>\n",
-                            "beacon": "<img src=\"https://tg.socdm.com/bc/v3?b=beaconID&amp;xuid=XUID&amp;ctsv=CTSV&amp;seqid=SeqID&amp;seqtime=SeqTime&amp;seqctx=SeqCtx&amp;t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
+                            "ad": "<!DOCTYPE html>\n  <head>\n    <meta charset=\"UTF-8\">\n  </head>\n  <body>\n    <div id=\"medibasspContainer\">sample-banner-android</div>\n  </body>\n",
+                            "beacon": "<img src=\"https://tg.socdm.com/bc/v3?b=beaconID&t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
                             "beaconurl": "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif",
                             "cpm": 46.6,
                             "creativeid": "Dummy_supership.jp",
+                            "dealid": "test-deal-id",
                             "h": 250,
-                            "landing_url": "",
-                            "scheduleid": "512601",
-                            "trackers": {
-                                "imp": [
-                                    "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif"
-                                ],
-                                "viewable_imp": [
-                                    "https://tg.socdm.com/aux/inview?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                                ],
-                                "viewable_measured": [
-                                    "https://tg.socdm.com/aux/measured?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                                ]
-                            },
-                            "ttl": 10,
                             "w": 300,
-                            "weight": 1
+                            "ttl": 10,
+                            "landing_url": "",
+                            "scheduleid": "512601"
                         }
-                    ],
-                    "dealid": "test-deal-id",
-                    "rotation": "0",
-                    "scheduleid": "512601",
-                    "sdktype": "0",
-                    "trackers": {
-                        "imp": [
-                            "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif"
-                        ],
-                        "viewable_imp": [
-                            "https://tg.socdm.com/aux/inview?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                        ],
-                        "viewable_measured": [
-                            "https://tg.socdm.com/aux/measured?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                        ]
-                    },
-                    "ttl": 10,
-                    "w": 300
+                    ]
                 }
             }
         }
     ],
     "expectedBidResponses": [
         {
-          "currency": "JPY",
-          "bids": [
-            {
-              "bid": {
-                "id": "58278",
-                "impid": "some-impression-id",
-                "price": 46.6,
-                "adm": "<div id=\"medibasspContainer\">\n      <iframe src=\"https:\/\/s3-ap-northeast-1.amazonaws.com\/sdk-temp\/adg-sample-ad\/300x250.html?prc=-Cuepak&rd=https%3A%2F%2Ftg.socdm.com%2Frd%2Fv1%2Fz%2FhKFj2gDXY2hzbT0xOTgsZmJkZGMyNWEvNTgyNzgvU1NQTE9DLzUxMjYwMS83MjExNS43Njg1NS41MTI2MDEvMTA5MzkyNi82NDkxOS81ODI3ODpTU1BMT0M6Ki9jdD0xNTg1MjEyMDg1Nzg5O3NyPWh0dHBzO2RzcGlkPTMwMTtwcj16RGFfYVY0O3ByYj15UTtwcm89eVE7cHJvYz1KUFk7Y3JkMnk9MTA5LjQzMDAwMDAwMDAwMDAxO2NyeTJkPTAuMDA5MTM4MjYxOTAyNTg2MTI3MztpZHg9MDulc2VxaWTaACQ0NzFhM2JlNS1lYTQzLWRhZjAtYjhjZi1mNjJkNTA1N2Y5ZWOnc2VxdGltZa0xNTg1MjEyMDg1Nzg5pHh1aWS4WE52SVNNQ281bUlBQU1hN2dOUUFBQUFB%2Fp%2Fctsv%3Dm-ad226%3Bseqid%3D471a3be5-ea43-daf0-b8cf-f62d5057f9ec%3B%2Fg%2FU%3A%3Furl%3D\" style=\"border: 0px;\" width=\"300\" height=\"250\" frameborder=\"0\" scrolling=\"no\"><\/iframe>\n    <\/div>\n  <img src=\"https://tg.socdm.com/bc/v3?b=beaconID&amp;xuid=XUID&amp;ctsv=CTSV&amp;seqid=SeqID&amp;seqtime=SeqTime&amp;seqctx=SeqCtx&amp;t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
-                "crid": "Dummy_supership.jp",
-                "w": 300,
-                "h": 250,
-                "dealid": "test-deal-id"
-              },
-              "type": "banner"
-            }
-          ]
+            "currency": "JPY",
+            "bids": [
+                {
+                    "bid": {
+                        "id": "58278",
+                        "impid": "some-impression-id",
+                        "price": 46.6,
+                        "adm": "<div id=\"medibasspContainer\">sample-banner-android</div>\n  <img src=\"https://tg.socdm.com/bc/v3?b=beaconID&t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
+                        "crid": "Dummy_supership.jp",
+                        "w": 300,
+                        "h": 250,
+                        "dealid": "test-deal-id"
+                    },
+                    "type": "banner"
+                }
+            ]
         }
-      ]
+    ]
 }
-

--- a/adapters/adgeneration/adgenerationtest/exemplary/single-banner-android.json
+++ b/adapters/adgeneration/adgenerationtest/exemplary/single-banner-android.json
@@ -36,7 +36,7 @@
     "httpCalls": [
         {
             "expectedRequest": {
-                "uri": "https://d.socdm.com/adgen/prebid?id=58278&posall=SSPLOC&sdktype=0",
+                "uri": "https://d.socdm.com/adgen/prebid?id=58278&posall=SSPLOC&sdktype=1",
                 "body": {
                     "currency": "JPY",
                     "pbver": "unknown",

--- a/adapters/adgeneration/adgenerationtest/exemplary/single-banner-android.json
+++ b/adapters/adgeneration/adgenerationtest/exemplary/single-banner-android.json
@@ -41,7 +41,7 @@
                     "currency": "JPY",
                     "pbver": "unknown",
                     "sdkname": "prebidserver",
-                    "adapterver": "1.0.3",
+                    "adapterver": "1.6.6",
                     "ortb": {
                         "id": "some-request-id",
                         "imp": [

--- a/adapters/adgeneration/adgenerationtest/exemplary/single-banner-ios.json
+++ b/adapters/adgeneration/adgenerationtest/exemplary/single-banner-ios.json
@@ -1,5 +1,5 @@
 {
-    "mockBidRequest":{
+    "mockBidRequest": {
         "id": "some-request-id",
         "site": {
             "page": "http://example.com/test.html"
@@ -35,33 +35,49 @@
     },
     "httpCalls": [
         {
-            "internalRequest": {
-                "id": "some-request-id",
-                "site": {
-                    "page": "http://example.com/test.html"
-                },
-                "imp": [
-                    {
-                        "id": "some-impression-id",
-                        "banner": {
-                            "format": [
-                                {
-                                    "w": 300,
-                                    "h": 250
+            "expectedRequest": {
+                "uri": "https://d.socdm.com/adgen/prebid?id=58278&posall=SSPLOC&sdktype=0",
+                "body": {
+                    "currency": "JPY",
+                    "pbver": "unknown",
+                    "sdkname": "prebidserver",
+                    "adapterver": "1.0.3",
+                    "ortb": {
+                        "id": "some-request-id",
+                        "imp": [
+                            {
+                                "id": "some-impression-id",
+                                "banner": {
+                                    "format": [
+                                        {
+                                            "w": 300,
+                                            "h": 250
+                                        }
+                                    ]
+                                },
+                                "ext": {
+                                    "bidder": {
+                                        "id": "58278"
+                                    }
                                 }
-                            ]
-                        },
-                        "ext": {
-                            "bidder": {
-                                "id": "58278"
                             }
-                        }
-                    }
-                ],
-                "tmax": 500
-            },
-            "expectedRequest":{
-                "uri": "https://d.socdm.com/adsv/v1?adapterver=1.0.3&appbundle=adgneration&currency=JPY&hb=true&id=58278&idfa=idfa&posall=SSPLOC&sdkname=prebidserver&sdktype=2&sizes=300x250&t=json3&tp=http%3A%2F%2Fexample.com%2Ftest.html",
+                        ],
+                        "site": {
+                            "page": "http://example.com/test.html"
+                        },
+                        "app": {
+                            "bundle": "adgneration"
+                        },
+                        "device": {
+                            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36",
+                            "ip": "0.0.0.0",
+                            "os": "ios",
+                            "ifa": "idfa"
+                        },
+                        "tmax": 500
+                    },
+                    "imark": 1
+                },
                 "headers": {
                     "Accept": [
                         "application/json"
@@ -76,92 +92,49 @@
                         "0.0.0.0"
                     ]
                 },
-                "impIDs":["some-impression-id"]
+                "impIDs": ["some-impression-id"]
             },
-            "mockResponse":{
+            "mockResponse": {
                 "status": 200,
                 "body": {
-                    "ad": "<!DOCTYPE html>\n  <head>\n    <meta charset=\"UTF-8\">\n    <script src=\"https:\/\/i.socdm.com\/sdk\/js\/adg-script-base.js\" type=\"text\/javascript\"><\/script>\n    <script type=\"text\/javascript\">\n      adsettings = {\n        locationid  : 58278,\n        rotation    : 0,\n        displaytype : 1,\n        sdktype     : \"0\",\n        scheduleid  : 512601\n      };\n    <\/script>\n    <style>\n      body {\n        margin:0;\n        padding:0;\n      }\n    <\/style>\n  <\/head>\n  <body>\n    <div id=\"medibasspContainer\">\n      <iframe src=\"https:\/\/s3-ap-northeast-1.amazonaws.com\/sdk-temp\/adg-sample-ad\/300x250.html?prc=-Cuepak&rd=https%3A%2F%2Ftg.socdm.com%2Frd%2Fv1%2Fz%2FhKFj2gDXY2hzbT0xOTgsZmJkZGMyNWEvNTgyNzgvU1NQTE9DLzUxMjYwMS83MjExNS43Njg1NS41MTI2MDEvMTA5MzkyNi82NDkxOS81ODI3ODpTU1BMT0M6Ki9jdD0xNTg1MjEyMDg1Nzg5O3NyPWh0dHBzO2RzcGlkPTMwMTtwcj16RGFfYVY0O3ByYj15UTtwcm89eVE7cHJvYz1KUFk7Y3JkMnk9MTA5LjQzMDAwMDAwMDAwMDAxO2NyeTJkPTAuMDA5MTM4MjYxOTAyNTg2MTI3MztpZHg9MDulc2VxaWTaACQ0NzFhM2JlNS1lYTQzLWRhZjAtYjhjZi1mNjJkNTA1N2Y5ZWOnc2VxdGltZa0xNTg1MjEyMDg1Nzg5pHh1aWS4WE52SVNNQ281bUlBQU1hN2dOUUFBQUFB%2Fp%2Fctsv%3Dm-ad226%3Bseqid%3D471a3be5-ea43-daf0-b8cf-f62d5057f9ec%3B%2Fg%2FU%3A%3Furl%3D\" style=\"border: 0px;\" width=\"300\" height=\"250\" frameborder=\"0\" scrolling=\"no\"><\/iframe>\n    <\/div>\n  <\/body>\n",
-                    "beacon": "<img src=\"https://tg.socdm.com/bc/v3?b=beaconID&amp;xuid=XUID&amp;ctsv=CTSV&amp;seqid=SeqID&amp;seqtime=SeqTime&amp;seqctx=SeqCtx&amp;t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
-                    "beaconurl": "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif",
-                    "cpm": 46.6,
-                    "creativeid": "Dummy_supership.jp",
-                    "displaytype": "1",
-                    "h": 250,
-                    "ids": {
-                        "anid": "",
-                        "diid": "",
-                        "idfa": "",
-                        "soc": "Soc"
-                    },
-                    "location_params": null,
                     "locationid": "58278",
                     "results": [
                         {
-                            "ad": "<!DOCTYPE html>\n  <head>\n    <meta charset=\"UTF-8\">\n    <script src=\"https:\/\/i.socdm.com\/sdk\/js\/adg-script-base.js\" type=\"text\/javascript\"><\/script>\n    <script type=\"text\/javascript\">\n      adsettings = {\n        locationid  : 58278,\n        rotation    : 0,\n        displaytype : 1,\n        sdktype     : \"0\",\n        scheduleid  : 512601\n      };\n    <\/script>\n    <style>\n      body {\n        margin:0;\n        padding:0;\n      }\n    <\/style>\n  <\/head>\n  <body>\n    <div id=\"medibasspContainer\">\n      <iframe src=\"https:\/\/s3-ap-northeast-1.amazonaws.com\/sdk-temp\/adg-sample-ad\/300x250.html?prc=-Cuepak&rd=https%3A%2F%2Ftg.socdm.com%2Frd%2Fv1%2Fz%2FhKFj2gDXY2hzbT0xOTgsZmJkZGMyNWEvNTgyNzgvU1NQTE9DLzUxMjYwMS83MjExNS43Njg1NS41MTI2MDEvMTA5MzkyNi82NDkxOS81ODI3ODpTU1BMT0M6Ki9jdD0xNTg1MjEyMDg1Nzg5O3NyPWh0dHBzO2RzcGlkPTMwMTtwcj16RGFfYVY0O3ByYj15UTtwcm89eVE7cHJvYz1KUFk7Y3JkMnk9MTA5LjQzMDAwMDAwMDAwMDAxO2NyeTJkPTAuMDA5MTM4MjYxOTAyNTg2MTI3MztpZHg9MDulc2VxaWTaACQ0NzFhM2JlNS1lYTQzLWRhZjAtYjhjZi1mNjJkNTA1N2Y5ZWOnc2VxdGltZa0xNTg1MjEyMDg1Nzg5pHh1aWS4WE52SVNNQ281bUlBQU1hN2dOUUFBQUFB%2Fp%2Fctsv%3Dm-ad226%3Bseqid%3D471a3be5-ea43-daf0-b8cf-f62d5057f9ec%3B%2Fg%2FU%3A%3Furl%3D\" style=\"border: 0px;\" width=\"300\" height=\"250\" frameborder=\"0\" scrolling=\"no\"><\/iframe>\n    <\/div>\n  <\/body>\n",
-                            "beacon": "<img src=\"https://tg.socdm.com/bc/v3?b=beaconID&amp;xuid=XUID&amp;ctsv=CTSV&amp;seqid=SeqID&amp;seqtime=SeqTime&amp;seqctx=SeqCtx&amp;t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
+                            "ad": "<!DOCTYPE html>\n  <head>\n    <meta charset=\"UTF-8\">\n  </head>\n  <body>\n    <div id=\"medibasspContainer\">sample-banner-ios</div>\n  </body>\n",
+                            "beacon": "<img src=\"https://tg.socdm.com/bc/v3?b=beaconID&t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
                             "beaconurl": "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif",
                             "cpm": 46.6,
                             "creativeid": "Dummy_supership.jp",
+                            "dealid": "test-deal-id",
                             "h": 250,
-                            "landing_url": "",
-                            "scheduleid": "512601",
-                            "trackers": {
-                                "imp": [
-                                    "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif"
-                                ],
-                                "viewable_imp": [
-                                    "https://tg.socdm.com/aux/inview?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                                ],
-                                "viewable_measured": [
-                                    "https://tg.socdm.com/aux/measured?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                                ]
-                            },
-                            "ttl": 10,
                             "w": 300,
-                            "weight": 1
+                            "ttl": 10,
+                            "landing_url": "",
+                            "scheduleid": "512601"
                         }
-                    ],
-                    "dealid": "test-deal-id",
-                    "rotation": "0",
-                    "scheduleid": "512601",
-                    "sdktype": "0",
-                    "trackers": {
-                        "imp": [
-                            "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif"
-                        ],
-                        "viewable_imp": [
-                            "https://tg.socdm.com/aux/inview?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                        ],
-                        "viewable_measured": [
-                            "https://tg.socdm.com/aux/measured?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                        ]
-                    },
-                    "ttl": 10,
-                    "w": 300
+                    ]
                 }
             }
         }
     ],
     "expectedBidResponses": [
         {
-          "currency": "JPY",
-          "bids": [
-            {
-              "bid": {
-                "id": "58278",
-                "impid": "some-impression-id",
-                "price": 46.6,
-                "adm": "<div id=\"medibasspContainer\">\n      <iframe src=\"https:\/\/s3-ap-northeast-1.amazonaws.com\/sdk-temp\/adg-sample-ad\/300x250.html?prc=-Cuepak&rd=https%3A%2F%2Ftg.socdm.com%2Frd%2Fv1%2Fz%2FhKFj2gDXY2hzbT0xOTgsZmJkZGMyNWEvNTgyNzgvU1NQTE9DLzUxMjYwMS83MjExNS43Njg1NS41MTI2MDEvMTA5MzkyNi82NDkxOS81ODI3ODpTU1BMT0M6Ki9jdD0xNTg1MjEyMDg1Nzg5O3NyPWh0dHBzO2RzcGlkPTMwMTtwcj16RGFfYVY0O3ByYj15UTtwcm89eVE7cHJvYz1KUFk7Y3JkMnk9MTA5LjQzMDAwMDAwMDAwMDAxO2NyeTJkPTAuMDA5MTM4MjYxOTAyNTg2MTI3MztpZHg9MDulc2VxaWTaACQ0NzFhM2JlNS1lYTQzLWRhZjAtYjhjZi1mNjJkNTA1N2Y5ZWOnc2VxdGltZa0xNTg1MjEyMDg1Nzg5pHh1aWS4WE52SVNNQ281bUlBQU1hN2dOUUFBQUFB%2Fp%2Fctsv%3Dm-ad226%3Bseqid%3D471a3be5-ea43-daf0-b8cf-f62d5057f9ec%3B%2Fg%2FU%3A%3Furl%3D\" style=\"border: 0px;\" width=\"300\" height=\"250\" frameborder=\"0\" scrolling=\"no\"><\/iframe>\n    <\/div>\n  <img src=\"https://tg.socdm.com/bc/v3?b=beaconID&amp;xuid=XUID&amp;ctsv=CTSV&amp;seqid=SeqID&amp;seqtime=SeqTime&amp;seqctx=SeqCtx&amp;t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
-                "crid": "Dummy_supership.jp",
-                "w": 300,
-                "h": 250,
-                "dealid": "test-deal-id"
-              },
-              "type": "banner"
-            }
-          ]
+            "currency": "JPY",
+            "bids": [
+                {
+                    "bid": {
+                        "id": "58278",
+                        "impid": "some-impression-id",
+                        "price": 46.6,
+                        "adm": "<div id=\"medibasspContainer\">sample-banner-ios</div>\n  <img src=\"https://tg.socdm.com/bc/v3?b=beaconID&t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
+                        "crid": "Dummy_supership.jp",
+                        "w": 300,
+                        "h": 250,
+                        "dealid": "test-deal-id"
+                    },
+                    "type": "banner"
+                }
+            ]
         }
-      ]
+    ]
 }
-

--- a/adapters/adgeneration/adgenerationtest/exemplary/single-banner-ios.json
+++ b/adapters/adgeneration/adgenerationtest/exemplary/single-banner-ios.json
@@ -36,7 +36,7 @@
     "httpCalls": [
         {
             "expectedRequest": {
-                "uri": "https://d.socdm.com/adgen/prebid?id=58278&posall=SSPLOC&sdktype=0",
+                "uri": "https://d.socdm.com/adgen/prebid?id=58278&posall=SSPLOC&sdktype=2",
                 "body": {
                     "currency": "JPY",
                     "pbver": "unknown",

--- a/adapters/adgeneration/adgenerationtest/exemplary/single-banner-ios.json
+++ b/adapters/adgeneration/adgenerationtest/exemplary/single-banner-ios.json
@@ -41,7 +41,7 @@
                     "currency": "JPY",
                     "pbver": "unknown",
                     "sdkname": "prebidserver",
-                    "adapterver": "1.0.3",
+                    "adapterver": "1.6.6",
                     "ortb": {
                         "id": "some-request-id",
                         "imp": [

--- a/adapters/adgeneration/adgenerationtest/exemplary/single-banner.json
+++ b/adapters/adgeneration/adgenerationtest/exemplary/single-banner.json
@@ -1,5 +1,5 @@
 {
-    "mockBidRequest":{
+    "mockBidRequest": {
         "id": "some-request-id",
         "site": {
             "page": "http://example.com/test.html"
@@ -9,7 +9,7 @@
             "ip": "0.0.0.0"
         },
         "source": {
-            "TID": "transactionid"
+            "tid": "transactionid"
         },
         "imp": [
             {
@@ -33,33 +33,47 @@
     },
     "httpCalls": [
         {
-            "internalRequest": {
-                "id": "some-request-id",
-                "site": {
-                    "page": "http://example.com/test.html"
-                },
-                "imp": [
-                    {
-                        "id": "some-impression-id",
-                        "banner": {
-                            "format": [
-                                {
-                                    "w": 300,
-                                    "h": 250
+            "expectedRequest": {
+                "uri": "https://d.socdm.com/adgen/prebid?id=58278&posall=SSPLOC&sdktype=0",
+                "body": {
+                    "currency": "JPY",
+                    "pbver": "unknown",
+                    "sdkname": "prebidserver",
+                    "adapterver": "1.0.3",
+                    "ortb": {
+                        "id": "some-request-id",
+                        "imp": [
+                            {
+                                "id": "some-impression-id",
+                                "banner": {
+                                    "format": [
+                                        {
+                                            "w": 300,
+                                            "h": 250
+                                        }
+                                    ]
+                                },
+                                "ext": {
+                                    "bidder": {
+                                        "id": "58278"
+                                    }
                                 }
-                            ]
-                        },
-                        "ext": {
-                            "bidder": {
-                                "id": "58278"
                             }
+                        ],
+                        "site": {
+                            "page": "http://example.com/test.html"
+                        },
+                        "device": {
+                            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36",
+                            "ip": "0.0.0.0"
+                        },
+                        "tmax": 500,
+                        "source": {
+                            "tid": "transactionid"
                         }
-                    }
-                ],
-                "tmax": 500
-            },
-            "expectedRequest":{
-                "uri": "https://d.socdm.com/adsv/v1?adapterver=1.0.3&currency=JPY&hb=true&id=58278&posall=SSPLOC&sdkname=prebidserver&sdktype=0&sizes=300x250&t=json3&tp=http%3A%2F%2Fexample.com%2Ftest.html&transactionid=transactionid",
+                    },
+                    "imark": 1
+                },
                 "headers": {
                     "Accept": [
                         "application/json"
@@ -74,92 +88,49 @@
                         "0.0.0.0"
                     ]
                 },
-                "impIDs":["some-impression-id"]
+                "impIDs": ["some-impression-id"]
             },
-            "mockResponse":{
+            "mockResponse": {
                 "status": 200,
                 "body": {
-                    "ad": "<!DOCTYPE html>\n  <head>\n    <meta charset=\"UTF-8\">\n    <script src=\"https:\/\/i.socdm.com\/sdk\/js\/adg-script-base.js\" type=\"text\/javascript\"><\/script>\n    <script type=\"text\/javascript\">\n      adsettings = {\n        locationid  : 58278,\n        rotation    : 0,\n        displaytype : 1,\n        sdktype     : \"0\",\n        scheduleid  : 512601\n      };\n    <\/script>\n    <style>\n      body {\n        margin:0;\n        padding:0;\n      }\n    <\/style>\n  <\/head>\n  <body>\n    <div id=\"medibasspContainer\">\n      <iframe src=\"https:\/\/s3-ap-northeast-1.amazonaws.com\/sdk-temp\/adg-sample-ad\/300x250.html?prc=-Cuepak&rd=https%3A%2F%2Ftg.socdm.com%2Frd%2Fv1%2Fz%2FhKFj2gDXY2hzbT0xOTgsZmJkZGMyNWEvNTgyNzgvU1NQTE9DLzUxMjYwMS83MjExNS43Njg1NS41MTI2MDEvMTA5MzkyNi82NDkxOS81ODI3ODpTU1BMT0M6Ki9jdD0xNTg1MjEyMDg1Nzg5O3NyPWh0dHBzO2RzcGlkPTMwMTtwcj16RGFfYVY0O3ByYj15UTtwcm89eVE7cHJvYz1KUFk7Y3JkMnk9MTA5LjQzMDAwMDAwMDAwMDAxO2NyeTJkPTAuMDA5MTM4MjYxOTAyNTg2MTI3MztpZHg9MDulc2VxaWTaACQ0NzFhM2JlNS1lYTQzLWRhZjAtYjhjZi1mNjJkNTA1N2Y5ZWOnc2VxdGltZa0xNTg1MjEyMDg1Nzg5pHh1aWS4WE52SVNNQ281bUlBQU1hN2dOUUFBQUFB%2Fp%2Fctsv%3Dm-ad226%3Bseqid%3D471a3be5-ea43-daf0-b8cf-f62d5057f9ec%3B%2Fg%2FU%3A%3Furl%3D\" style=\"border: 0px;\" width=\"300\" height=\"250\" frameborder=\"0\" scrolling=\"no\"><\/iframe>\n    <\/div>\n  <\/body>\n",
-                    "beacon": "<img src=\"https://tg.socdm.com/bc/v3?b=beaconID&amp;xuid=XUID&amp;ctsv=CTSV&amp;seqid=SeqID&amp;seqtime=SeqTime&amp;seqctx=SeqCtx&amp;t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
-                    "beaconurl": "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif",
-                    "cpm": 46.6,
-                    "creativeid": "Dummy_supership.jp",
-                    "displaytype": "1",
-                    "h": 250,
-                    "ids": {
-                        "anid": "",
-                        "diid": "",
-                        "idfa": "",
-                        "soc": "Soc"
-                    },
-                    "location_params": null,
                     "locationid": "58278",
                     "results": [
                         {
-                            "ad": "<!DOCTYPE html>\n  <head>\n    <meta charset=\"UTF-8\">\n    <script src=\"https:\/\/i.socdm.com\/sdk\/js\/adg-script-base.js\" type=\"text\/javascript\"><\/script>\n    <script type=\"text\/javascript\">\n      adsettings = {\n        locationid  : 58278,\n        rotation    : 0,\n        displaytype : 1,\n        sdktype     : \"0\",\n        scheduleid  : 512601\n      };\n    <\/script>\n    <style>\n      body {\n        margin:0;\n        padding:0;\n      }\n    <\/style>\n  <\/head>\n  <body>\n    <div id=\"medibasspContainer\">\n      <iframe src=\"https:\/\/s3-ap-northeast-1.amazonaws.com\/sdk-temp\/adg-sample-ad\/300x250.html?prc=-Cuepak&rd=https%3A%2F%2Ftg.socdm.com%2Frd%2Fv1%2Fz%2FhKFj2gDXY2hzbT0xOTgsZmJkZGMyNWEvNTgyNzgvU1NQTE9DLzUxMjYwMS83MjExNS43Njg1NS41MTI2MDEvMTA5MzkyNi82NDkxOS81ODI3ODpTU1BMT0M6Ki9jdD0xNTg1MjEyMDg1Nzg5O3NyPWh0dHBzO2RzcGlkPTMwMTtwcj16RGFfYVY0O3ByYj15UTtwcm89eVE7cHJvYz1KUFk7Y3JkMnk9MTA5LjQzMDAwMDAwMDAwMDAxO2NyeTJkPTAuMDA5MTM4MjYxOTAyNTg2MTI3MztpZHg9MDulc2VxaWTaACQ0NzFhM2JlNS1lYTQzLWRhZjAtYjhjZi1mNjJkNTA1N2Y5ZWOnc2VxdGltZa0xNTg1MjEyMDg1Nzg5pHh1aWS4WE52SVNNQ281bUlBQU1hN2dOUUFBQUFB%2Fp%2Fctsv%3Dm-ad226%3Bseqid%3D471a3be5-ea43-daf0-b8cf-f62d5057f9ec%3B%2Fg%2FU%3A%3Furl%3D\" style=\"border: 0px;\" width=\"300\" height=\"250\" frameborder=\"0\" scrolling=\"no\"><\/iframe>\n    <\/div>\n  <\/body>\n",
-                            "beacon": "<img src=\"https://tg.socdm.com/bc/v3?b=beaconID&amp;xuid=XUID&amp;ctsv=CTSV&amp;seqid=SeqID&amp;seqtime=SeqTime&amp;seqctx=SeqCtx&amp;t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
+                            "ad": "<!DOCTYPE html>\n  <head>\n    <meta charset=\"UTF-8\">\n  </head>\n  <body>\n    <div id=\"medibasspContainer\">sample-banner</div>\n  </body>\n",
+                            "beacon": "<img src=\"https://tg.socdm.com/bc/v3?b=beaconID&t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
                             "beaconurl": "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif",
                             "cpm": 46.6,
                             "creativeid": "Dummy_supership.jp",
+                            "dealid": "test-deal-id",
                             "h": 250,
-                            "landing_url": "",
-                            "scheduleid": "512601",
-                            "trackers": {
-                                "imp": [
-                                    "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif"
-                                ],
-                                "viewable_imp": [
-                                    "https://tg.socdm.com/aux/inview?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                                ],
-                                "viewable_measured": [
-                                    "https://tg.socdm.com/aux/measured?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                                ]
-                            },
-                            "ttl": 10,
                             "w": 300,
-                            "weight": 1
+                            "ttl": 10,
+                            "landing_url": "",
+                            "scheduleid": "512601"
                         }
-                    ],
-                    "dealid": "test-deal-id",
-                    "rotation": "0",
-                    "scheduleid": "512601",
-                    "sdktype": "0",
-                    "trackers": {
-                        "imp": [
-                            "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif"
-                        ],
-                        "viewable_imp": [
-                            "https://tg.socdm.com/aux/inview?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                        ],
-                        "viewable_measured": [
-                            "https://tg.socdm.com/aux/measured?creative_id=1093926&ctsv=CTSC&extra_field=ExtraField&family_id=512601&id=58278&loglocation_id=64919&lookupname=58278%3ASSPLOC%3A*&pos=SSPLOC&schedule_id=72115.76855.512601&seqid=SeqID&seqtime=SeqTime&xuid=XUID"
-                        ]
-                    },
-                    "ttl": 10,
-                    "w": 300
+                    ]
                 }
             }
         }
     ],
     "expectedBidResponses": [
         {
-          "currency": "JPY",
-          "bids": [
-            {
-              "bid": {
-                "id": "58278",
-                "impid": "some-impression-id",
-                "price": 46.6,
-                "adm": "<div id=\"medibasspContainer\">\n      <iframe src=\"https:\/\/s3-ap-northeast-1.amazonaws.com\/sdk-temp\/adg-sample-ad\/300x250.html?prc=-Cuepak&rd=https%3A%2F%2Ftg.socdm.com%2Frd%2Fv1%2Fz%2FhKFj2gDXY2hzbT0xOTgsZmJkZGMyNWEvNTgyNzgvU1NQTE9DLzUxMjYwMS83MjExNS43Njg1NS41MTI2MDEvMTA5MzkyNi82NDkxOS81ODI3ODpTU1BMT0M6Ki9jdD0xNTg1MjEyMDg1Nzg5O3NyPWh0dHBzO2RzcGlkPTMwMTtwcj16RGFfYVY0O3ByYj15UTtwcm89eVE7cHJvYz1KUFk7Y3JkMnk9MTA5LjQzMDAwMDAwMDAwMDAxO2NyeTJkPTAuMDA5MTM4MjYxOTAyNTg2MTI3MztpZHg9MDulc2VxaWTaACQ0NzFhM2JlNS1lYTQzLWRhZjAtYjhjZi1mNjJkNTA1N2Y5ZWOnc2VxdGltZa0xNTg1MjEyMDg1Nzg5pHh1aWS4WE52SVNNQ281bUlBQU1hN2dOUUFBQUFB%2Fp%2Fctsv%3Dm-ad226%3Bseqid%3D471a3be5-ea43-daf0-b8cf-f62d5057f9ec%3B%2Fg%2FU%3A%3Furl%3D\" style=\"border: 0px;\" width=\"300\" height=\"250\" frameborder=\"0\" scrolling=\"no\"><\/iframe>\n    <\/div>\n  <img src=\"https://tg.socdm.com/bc/v3?b=beaconID&amp;xuid=XUID&amp;ctsv=CTSV&amp;seqid=SeqID&amp;seqtime=SeqTime&amp;seqctx=SeqCtx&amp;t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
-                "crid": "Dummy_supership.jp",
-                "w": 300,
-                "h": 250,
-                "dealid": "test-deal-id"
-              },
-              "type": "banner"
-            }
-          ]
+            "currency": "JPY",
+            "bids": [
+                {
+                    "bid": {
+                        "id": "58278",
+                        "impid": "some-impression-id",
+                        "price": 46.6,
+                        "adm": "<div id=\"medibasspContainer\">sample-banner</div>\n  <img src=\"https://tg.socdm.com/bc/v3?b=beaconID&t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
+                        "crid": "Dummy_supership.jp",
+                        "w": 300,
+                        "h": 250,
+                        "dealid": "test-deal-id"
+                    },
+                    "type": "banner"
+                }
+            ]
         }
-      ]
+    ]
 }
-

--- a/adapters/adgeneration/adgenerationtest/exemplary/single-banner.json
+++ b/adapters/adgeneration/adgenerationtest/exemplary/single-banner.json
@@ -39,7 +39,7 @@
                     "currency": "JPY",
                     "pbver": "unknown",
                     "sdkname": "prebidserver",
-                    "adapterver": "1.0.3",
+                    "adapterver": "1.6.6",
                     "ortb": {
                         "id": "some-request-id",
                         "imp": [

--- a/adapters/adgeneration/adgenerationtest/supplemental/204-bid-response.json
+++ b/adapters/adgeneration/adgenerationtest/supplemental/204-bid-response.json
@@ -1,5 +1,5 @@
 {
-    "mockBidRequest":{
+    "mockBidRequest": {
         "id": "some-request-id",
         "site": {
             "page": "http://example.com/test.html"
@@ -29,45 +29,44 @@
     },
     "httpCalls": [
         {
-            "internalRequest": {
-                "id": "some-request-id",
-                "site": {
-                    "page": "http://example.com/test.html"
-                },
-                "imp": [
-                    {
-                        "id": "some-impression-id",
-                        "banner": {
-                            "format": [
-                                {
-                                    "w": 300,
-                                    "h": 250
+            "expectedRequest": {
+                "uri": "https://d.socdm.com/adgen/prebid?id=58278&posall=SSPLOC&sdktype=0",
+                "body": {
+                    "currency": "JPY",
+                    "pbver": "unknown",
+                    "sdkname": "prebidserver",
+                    "adapterver": "1.0.3",
+                    "ortb": {
+                        "id": "some-request-id",
+                        "imp": [
+                            {
+                                "id": "some-impression-id",
+                                "banner": {
+                                    "format": [
+                                        {
+                                            "w": 300,
+                                            "h": 250
+                                        }
+                                    ]
+                                },
+                                "ext": {
+                                    "bidder": {
+                                        "id": "58278"
+                                    }
                                 }
-                            ]
-                        },
-                        "ext": {
-                            "bidder": {
-                                "id": "58278"
                             }
-                        }
-                    }
-                ],
-                "tmax": 500
-            },
-            "expectedRequest":{
-                "uri": "https://d.socdm.com/adsv/v1?adapterver=1.0.3&currency=JPY&hb=true&id=58278&posall=SSPLOC&sdkname=prebidserver&sdktype=0&sizes=300x250&t=json3&tp=http%3A%2F%2Fexample.com%2Ftest.html",
-                "headers": {
-                    "Accept": [
-                        "application/json"
-                    ],
-                    "Content-Type": [
-                        "application/json;charset=utf-8"
-                    ],
-                    "User-Agent": [
-                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36"
-                    ]
+                        ],
+                        "site": {
+                            "page": "http://example.com/test.html"
+                        },
+                        "device": {
+                            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36"
+                        },
+                        "tmax": 500
+                    },
+                    "imark": 1
                 },
-                "impIDs":["some-impression-id"]
+                "impIDs": ["some-impression-id"]
             },
             "mockResponse": {
                 "status": 204,

--- a/adapters/adgeneration/adgenerationtest/supplemental/204-bid-response.json
+++ b/adapters/adgeneration/adgenerationtest/supplemental/204-bid-response.json
@@ -35,7 +35,7 @@
                     "currency": "JPY",
                     "pbver": "unknown",
                     "sdkname": "prebidserver",
-                    "adapterver": "1.0.3",
+                    "adapterver": "1.6.6",
                     "ortb": {
                         "id": "some-request-id",
                         "imp": [

--- a/adapters/adgeneration/adgenerationtest/supplemental/400-bid-response.json
+++ b/adapters/adgeneration/adgenerationtest/supplemental/400-bid-response.json
@@ -1,5 +1,5 @@
 {
-    "mockBidRequest":{
+    "mockBidRequest": {
         "id": "some-request-id",
         "site": {
             "page": "http://example.com/test.html"
@@ -29,45 +29,44 @@
     },
     "httpCalls": [
         {
-            "internalRequest": {
-                "id": "some-request-id",
-                "site": {
-                    "page": "http://example.com/test.html"
-                },
-                "imp": [
-                    {
-                        "id": "some-impression-id",
-                        "banner": {
-                            "format": [
-                                {
-                                    "w": 300,
-                                    "h": 250
+            "expectedRequest": {
+                "uri": "https://d.socdm.com/adgen/prebid?id=58278&posall=SSPLOC&sdktype=0",
+                "body": {
+                    "currency": "JPY",
+                    "pbver": "unknown",
+                    "sdkname": "prebidserver",
+                    "adapterver": "1.0.3",
+                    "ortb": {
+                        "id": "some-request-id",
+                        "imp": [
+                            {
+                                "id": "some-impression-id",
+                                "banner": {
+                                    "format": [
+                                        {
+                                            "w": 300,
+                                            "h": 250
+                                        }
+                                    ]
+                                },
+                                "ext": {
+                                    "bidder": {
+                                        "id": "58278"
+                                    }
                                 }
-                            ]
-                        },
-                        "ext": {
-                            "bidder": {
-                                "id": "58278"
                             }
-                        }
-                    }
-                ],
-                "tmax": 500
-            },
-            "expectedRequest":{
-                "uri": "https://d.socdm.com/adsv/v1?adapterver=1.0.3&currency=JPY&hb=true&id=58278&posall=SSPLOC&sdkname=prebidserver&sdktype=0&sizes=300x250&t=json3&tp=http%3A%2F%2Fexample.com%2Ftest.html",
-                "headers": {
-                    "Accept": [
-                        "application/json"
-                    ],
-                    "Content-Type": [
-                        "application/json;charset=utf-8"
-                    ],
-                    "User-Agent": [
-                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36"
-                    ]
+                        ],
+                        "site": {
+                            "page": "http://example.com/test.html"
+                        },
+                        "device": {
+                            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36"
+                        },
+                        "tmax": 500
+                    },
+                    "imark": 1
                 },
-                "impIDs":["some-impression-id"]
+                "impIDs": ["some-impression-id"]
             },
             "mockResponse": {
                 "status": 400,
@@ -75,10 +74,11 @@
             }
         }
     ],
+    "expectedBidResponses": [],
     "expectedMakeBidsErrors": [
         {
-          "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
-          "comparison": "literal"
+            "value": "Unexpected status code: 400. Run with request.debug = 1 for more info",
+            "comparison": "literal"
         }
     ]
 }

--- a/adapters/adgeneration/adgenerationtest/supplemental/400-bid-response.json
+++ b/adapters/adgeneration/adgenerationtest/supplemental/400-bid-response.json
@@ -35,7 +35,7 @@
                     "currency": "JPY",
                     "pbver": "unknown",
                     "sdkname": "prebidserver",
-                    "adapterver": "1.0.3",
+                    "adapterver": "1.6.6",
                     "ortb": {
                         "id": "some-request-id",
                         "imp": [

--- a/adapters/adgeneration/adgenerationtest/supplemental/no-bid-response.json
+++ b/adapters/adgeneration/adgenerationtest/supplemental/no-bid-response.json
@@ -1,5 +1,5 @@
 {
-    "mockBidRequest":{
+    "mockBidRequest": {
         "id": "some-request-id",
         "site": {
             "page": "http://example.com/test.html"
@@ -29,68 +29,53 @@
     },
     "httpCalls": [
         {
-            "internalRequest": {
-                "id": "some-request-id",
-                "site": {
-                    "page": "http://example.com/test.html"
-                },
-                "imp": [
-                    {
-                        "id": "some-impression-id",
-                        "banner": {
-                            "format": [
-                                {
-                                    "w": 300,
-                                    "h": 250
+            "expectedRequest": {
+                "uri": "https://d.socdm.com/adgen/prebid?id=58278&posall=SSPLOC&sdktype=0",
+                "body": {
+                    "currency": "JPY",
+                    "pbver": "unknown",
+                    "sdkname": "prebidserver",
+                    "adapterver": "1.0.3",
+                    "ortb": {
+                        "id": "some-request-id",
+                        "imp": [
+                            {
+                                "id": "some-impression-id",
+                                "banner": {
+                                    "format": [
+                                        {
+                                            "w": 300,
+                                            "h": 250
+                                        }
+                                    ]
+                                },
+                                "ext": {
+                                    "bidder": {
+                                        "id": "58278"
+                                    }
                                 }
-                            ]
-                        },
-                        "ext": {
-                            "bidder": {
-                                "id": "58278"
                             }
-                        }
-                    }
-                ],
-                "tmax": 500
-            },
-            "expectedRequest":{
-                "uri": "https://d.socdm.com/adsv/v1?adapterver=1.0.3&currency=JPY&hb=true&id=58278&posall=SSPLOC&sdkname=prebidserver&sdktype=0&sizes=300x250&t=json3&tp=http%3A%2F%2Fexample.com%2Ftest.html",
-                "headers": {
-                    "Accept": [
-                        "application/json"
-                    ],
-                    "Content-Type": [
-                        "application/json;charset=utf-8"
-                    ],
-                    "User-Agent": [
-                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36"
-                    ]
+                        ],
+                        "site": {
+                            "page": "http://example.com/test.html"
+                        },
+                        "device": {
+                            "ua": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36"
+                        },
+                        "tmax": 500
+                    },
+                    "imark": 1
                 },
-                "impIDs":["some-impression-id"]
+                "impIDs": ["some-impression-id"]
             },
-            "mockResponse":{
+            "mockResponse": {
                 "status": 200,
                 "body": {
-                    "ad": "<!-- st=noad : id=58278 : pos=SSPLOC -->\n",
-                    "beacon": "<img src=\"https://tg.socdm.com/bc/v3?b=beaconID&amp;xuid=XUID&amp;ctsv=CTSV&amp;seqid=SeqID&amp;seqtime=SeqTime&amp;seqctx=SeqCtx&amp;t=.gif\" width=\"1\" height=\"1\" style=\"display:none;border:none;padding:0;margin:0;width:1px;height:1px\"/>",
-                    "beaconurl": "https://tg.socdm.com/bc/v3?b=beaconID&t=.gif",
-                    "displaytype": "1",
-                    "ids": {
-                        "anid": "",
-                        "diid": "",
-                        "idfa": "",
-                        "soc": "XNvISMCo5mIAAMa7gNQAAAAA"
-                    },
-                    "location_params": null,
                     "locationid": "58278",
-                    "results": [],
-                    "rotation": "0",
-                    "sdktype": "0"
+                    "results": []
                 }
             }
         }
     ],
     "expectedBidResponses": []
 }
-

--- a/adapters/adgeneration/adgenerationtest/supplemental/no-bid-response.json
+++ b/adapters/adgeneration/adgenerationtest/supplemental/no-bid-response.json
@@ -35,7 +35,7 @@
                     "currency": "JPY",
                     "pbver": "unknown",
                     "sdkname": "prebidserver",
-                    "adapterver": "1.0.3",
+                    "adapterver": "1.6.6",
                     "ortb": {
                         "id": "some-request-id",
                         "imp": [

--- a/openrtb_ext/imp_adgeneration.go
+++ b/openrtb_ext/imp_adgeneration.go
@@ -2,4 +2,7 @@ package openrtb_ext
 
 type ExtImpAdgeneration struct {
 	Id string `json:"id"`
+	// MarginTop は upper_billboard 配置で ADGBrowserM.init({marginTop}) に渡す値。
+	// Prebid.js 側 (bidder params.marginTop) と挙動を揃えるための任意項目。
+	MarginTop string `json:"marginTop,omitempty"`
 }

--- a/static/bidder-info/adgeneration.yaml
+++ b/static/bidder-info/adgeneration.yaml
@@ -1,10 +1,14 @@
-endpoint: "https://d.socdm.com/adsv/v1"
+# Prebid.js v1.6.6 と仕様を合わせる目的で /adgen/prebid (POST) に変更。
+# 詳細: projects/prebid-server/research/parity-concerns.md
+endpoint: "https://d.socdm.com/adgen/prebid"
 maintainer:
   email: "ssp-ope@supership.jp"
 capabilities:
   app:
     mediaTypes:
       - banner
+      - native
   site:
     mediaTypes:
       - banner
+      - native

--- a/static/bidder-info/adgeneration.yaml
+++ b/static/bidder-info/adgeneration.yaml
@@ -8,6 +8,8 @@ capabilities:
     mediaTypes:
       - banner
       - native
+      # video: Prebid Mobile の video ad unit 向け。imp.video のとき VAST を生のまま返す
+      - video
   site:
     mediaTypes:
       - banner

--- a/static/bidder-info/adgeneration.yaml
+++ b/static/bidder-info/adgeneration.yaml
@@ -20,3 +20,7 @@ userSync:
   redirect:
     url: "https://d.socdm.com/getuid?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redirect={{.RedirectURL}}"
     userMacro: "$UID"
+  # NOT enabled yet: the d.socdm.com /getuid endpoint and user.buyeruid consumption are not
+  # implemented on the backend yet. Keep this syncer disabled by default. A host can turn it on
+  # via config (adapters.adgeneration.usersync.enabled) once the backend is ready.
+  enabled: false

--- a/static/bidder-info/adgeneration.yaml
+++ b/static/bidder-info/adgeneration.yaml
@@ -8,8 +8,6 @@ capabilities:
     mediaTypes:
       - banner
       - native
-      # video: Prebid Mobile の video ad unit 向け。imp.video のとき VAST を生のまま返す
-      - video
   site:
     mediaTypes:
       - banner

--- a/static/bidder-info/adgeneration.yaml
+++ b/static/bidder-info/adgeneration.yaml
@@ -12,3 +12,9 @@ capabilities:
     mediaTypes:
       - banner
       - native
+# cookie-sync (S2S) 検証用。getuid URL / userMacro は backend 仕様確定後に差し替える。
+# 詳細: projects/prebid-server/design/cookie-sync-s2s-design.md
+userSync:
+  redirect:
+    url: "https://d.socdm.com/getuid?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&redirect={{.RedirectURL}}"
+    userMacro: "$UID"

--- a/static/bidder-params/adgeneration.json
+++ b/static/bidder-params/adgeneration.json
@@ -8,6 +8,10 @@
         "id": {
           "type": "string",
           "description": "Ad ID registered by AdGeneration."
+        },
+        "marginTop": {
+          "type": "string",
+          "description": "marginTop passed to ADGBrowserM.init for upper_billboard placements (matches Prebid.js bidder params)."
         }
     },
     "required": ["id"]


### PR DESCRIPTION
## Summary
- Prebid.js v1.6.6 の `adgenerationBidAdapter` に仕様を合わせ、`adgeneration` アダプターを書き換え
- リクエストを `GET /adsv/v1` (URL クエリ) から `POST /adgen/prebid` (ortb JSON body) に変更
- Native mediaType を app / site の両方で対応
- 単体テスト (10 件) を新 API に書き換え、すべて pass

## 主な変更
- **エンドポイント**: `https://d.socdm.com/adsv/v1` → `https://d.socdm.com/adgen/prebid`
- **メソッド**: GET → POST、body に ortb リクエスト全体を JSON で送信
- **Native 対応**: `static/bidder-info/adgeneration.yaml` の capability に `native` を追加 (app / site 両方)
- **レスポンス読み取り**: body トップレベル → `results[0]` 優先 (prebid.js 実装と一致)
- **sdktype**: OS 別 (0/1/2) を廃止し `0` 固定 (prebid.js パリティ優先)
- **idfa / advertising_id**: 単独クエリ送信を廃止し `device.ifa` に集約
- **Native AdM**: `wrapNativeAdm` で `{"native":{...}}` と `{assets:...}` の両形式を吸収 (バックエンド応答形式未確定のため両対応)
- **その他**: `ADomain` (旧 `adomain`)、`location_params` / `upper_billboard` 判定、`ADGBrowserMTag` を追加

## 残作業
- `adapters/adgeneration/adgenerationtest/` 配下の JSON golden file (exemplary / supplemental) は旧 GET 形式のまま。`TestJsonSamples` は `t.Skip` で退避中。POST + JSON body 形式への書き換えが別途必要
- バックエンド (`d.socdm.com/adgen/prebid`) が `sdkname=prebidserver` のリクエストを受けて `results[]` 形式で応答できるか要確認
- `sdktype=0` 固定で app 配信のバックエンド処理に影響がないか要確認
- ステージング 1 媒体での疎通確認

## 背景
- 4 年以上メンテされていなかった `adgeneration` アダプターを Prebid.js 版と揃える施策
- 詳細調査: `projects/prebid-server/research/parity-concerns.md` (社内資料)

## Test plan
- [x] `go build ./...` 通過
- [x] `go test ./adapters/adgeneration/...` 通過 (10 件、`TestJsonSamples` は Skip)
- [ ] golden file 書き換え後に `TestJsonSamples` を有効化して通過確認
- [ ] バックエンド `/adgen/prebid` 仕様確認後、ステージングで疎通確認